### PR TITLE
MODPERMS-47 re-enable api-docs and lint-raml jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,9 @@
 
 buildMvn {
   publishModDescriptor = 'yes'
-  publishAPI = 'no'
+  publishAPI = 'yes'
   mvnDeploy = 'yes'
-  runLintRamlCop = 'no'
+  runLintRamlCop = 'yes'
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
These were temporarily off during the first phase of RAMLs re-arrangement.

I expect the next phase of re-arrangement to be handled gracefully, and can follow-up later with adjusted configuration.
