### PR TITLE
Add indexes to improve permission related query performance

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -10,7 +10,9 @@
       "uniqueIndex" : [
         {
           "fieldName" : "permissionName",
-          "tOps" : "ADD"
+          "tOps" : "ADD",
+          "caseSensitive": true,
+          "removeAccents": false
         }
       ]
     },
@@ -19,7 +21,29 @@
       "generateId" : true,
       "fromModuleVersion" : "5.0",
       "withMetadata" : true,
-      "pkColumnName": "_id"
+      "pkColumnName": "_id",
+      "index" : [
+        {
+          "fieldName" : "id",
+          "tOps" : "ADD",
+          "caseSensitive": true,
+          "removeAccents": false
+        },
+        {
+          "fieldName" : "userId",
+          "tOps" : "ADD",
+          "caseSensitive": true,
+          "removeAccents": false
+        }
+      ],
+      "ginIndex": [
+        {
+          "fieldName": "userId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     }
   ],
   "views" : []


### PR DESCRIPTION
Add a few indexes to improve permission related query performance. The GIN index on userId field reduced related query execution time from **100ms to a few ms**. The b-tree indexes on id and userId fields reduced related query execution time from **10ms to under 0.1ms**. The adjusted Unique index reduced related query execution time from **a few ms to under 0.1ms**.  The numbers are from BugFest 2.1 environment.