### PR TITLE
MODPERMS-59: use cache to further improve performance

### DIFF
--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -1498,6 +1498,13 @@ public class PermsAPI implements Perms {
       future.complete(new ArrayList<>());
       return future;
     }
+
+    // use cache by default unless set to false explicitly
+    Boolean usePermsCache = vertxContext.config().getBoolean(PermsCache.CACHE_HEADER);
+    if (usePermsCache == null || usePermsCache) {
+      return PermsCache.expandPerms(permissionList, vertxContext, tenantId);
+    }
+
     try {
       Criterion criterion = buildPermissionNameListQuery(permissionList);
       PostgresClient pgClient = PostgresClient.getInstance(vertxContext.owner(),
@@ -1602,6 +1609,13 @@ public class PermsAPI implements Perms {
       });
       return future;
     }
+
+    // use cache by default unless set to false explicitly
+    Boolean usePermsCache = vertxContext.config().getBoolean(PermsCache.CACHE_HEADER);
+    if (usePermsCache == null || usePermsCache) {
+      return PermsCache.expandPerms(permissionList, vertxContext, tenantId);
+    }
+
     try {
       Criterion criterion = buildPermissionNameListQuery(permissionList);
       PostgresClient pgClient = PostgresClient.getInstance(vertxContext.owner(),

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -1610,12 +1610,6 @@ public class PermsAPI implements Perms {
       return future;
     }
 
-    // use cache by default unless set to false explicitly
-    Boolean usePermsCache = vertxContext.config().getBoolean(PermsCache.CACHE_HEADER);
-    if (usePermsCache == null || usePermsCache) {
-      return PermsCache.expandPerms(permissionList, vertxContext, tenantId);
-    }
-
     try {
       Criterion criterion = buildPermissionNameListQuery(permissionList);
       PostgresClient pgClient = PostgresClient.getInstance(vertxContext.owner(),

--- a/src/main/java/org/folio/rest/impl/PermsCache.java
+++ b/src/main/java/org/folio/rest/impl/PermsCache.java
@@ -1,0 +1,246 @@
+package org.folio.rest.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.folio.rest.persist.PostgresClient;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+/**
+ * A simple cache to avoid frequent database calls to get sub permissions.
+ *
+ * @author hji
+ *
+ */
+public class PermsCache {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PermsCache.class);
+
+  public static final String CACHE_HEADER = "use.perms.cache";
+
+  private static final long CACHE_PERIOD = 30 * 1000;
+
+  private static final String QUERY_PERMS = "select jsonb->>'permissionName' as p_name, jsonb->>'subPermissions' as p_sub from %s_mod_permissions.permissions";
+  private static final String PERMS_PNAME = "p_name";
+  private static final String PERMS_PSUB = "p_sub";
+
+  private static final String QUERY_PG_STAT = "select n_tup_ins, n_tup_upd, n_tup_del from pg_stat_user_tables where schemaname = '%s_mod_permissions' and relname = 'permissions'";
+  private static final String PG_STAT_INS = "n_tup_ins";
+  private static final String PG_STAT_UPD = "n_tup_upd";
+  private static final String PG_STAT_DEL = "n_tup_del";
+
+  private static final ConcurrentMap<String, PermCache> CACHE = new ConcurrentHashMap<>();
+
+  /**
+   * Expand permission list to include all sub permissions recursively.
+   *
+   * @param perms
+   * @param vertxContext
+   * @param tenantId
+   * @return
+   */
+  public static Future<List<String>> expandPerms(List<String> perms, Context vertxContext, String tenantId) {
+    Future<List<String>> future = Future.future();
+    PermCache permCache = CACHE.get(tenantId);
+    if (permCache == null) {
+      LOGGER.info("Populate perms cache for tenant " + tenantId);
+      Future<PgStat> f1 = queryPermsPgStat(vertxContext, tenantId);
+      Future<Map<String, Set<String>>> f2 = queryAllPerms(vertxContext, tenantId);
+      CompositeFuture.all(f1, f2).setHandler(ar -> {
+        if (ar.succeeded()) {
+          PermCache pc = new PermCache(f1.result(), f2.result());
+          LOGGER.debug("new perms cache: " + pc);
+          CACHE.put(tenantId, pc);
+          future.complete(pc.expandPerms(perms));
+        } else {
+          future.fail(ar.cause());
+        }
+      });
+    } else if (permCache.isStale()) {
+      Future<PgStat> f1 = queryPermsPgStat(vertxContext, tenantId);
+      f1.setHandler(ar -> {
+        if (ar.succeeded()) {
+          if (ar.result().equals(permCache.pgStat)) {
+            LOGGER.debug("Reset perm cache timestamp for tenant " + tenantId);
+            permCache.resetTimeStamp();
+            future.complete(permCache.expandPerms(perms));
+          } else {
+            LOGGER.info("Update perms cache for tenant " + tenantId);
+            Future<Map<String, Set<String>>> f2 = queryAllPerms(vertxContext, tenantId);
+            f2.setHandler(ar2 -> {
+              if (ar2.succeeded()) {
+                PermCache pc = new PermCache(f1.result(), f2.result());
+                LOGGER.debug("upated perms cache: " + pc);
+                CACHE.put(tenantId, pc);
+                future.complete(pc.expandPerms(perms));
+              } else {
+                future.fail(ar2.cause());
+              }
+            });
+          }
+        } else {
+          future.fail(ar.cause());
+        }
+      });
+    } else {
+      future.complete(permCache.expandPerms(perms));
+    }
+    return future;
+  }
+
+  private static Future<PgStat> queryPermsPgStat(Context vertxContext, String tenantId) {
+    Future<PgStat> future = Future.future();
+    String query = String.format(QUERY_PG_STAT, tenantId.toLowerCase());
+    PostgresClient pc = PostgresClient.getInstance(vertxContext.owner(), tenantId);
+    pc.select(query, reply -> {
+      if (reply.succeeded()) {
+        JsonObject jo = reply.result().getRows().get(0);
+        PgStat pgStat = new PgStat(jo.getInteger(PG_STAT_INS), jo.getInteger(PG_STAT_UPD), jo.getInteger(PG_STAT_DEL));
+        future.complete(pgStat);
+      } else {
+        future.fail(reply.cause());
+      }
+    });
+    return future;
+  }
+
+  private static Future<Map<String, Set<String>>> queryAllPerms(Context vertxContext, String tenantId) {
+    Future<Map<String, Set<String>>> future = Future.future();
+    String query = String.format(QUERY_PERMS, tenantId.toLowerCase());
+    PostgresClient pc = PostgresClient.getInstance(vertxContext.owner(), tenantId);
+    Map<String, Set<String>> perms = new HashMap<>();
+    pc.select(query, reply -> {
+      if (reply.succeeded()) {
+        reply.result().getRows().forEach(jo -> {
+          String pname = jo.getString(PERMS_PNAME);
+          String psub = jo.getString(PERMS_PSUB);
+          Set<String> subs = new HashSet<>();
+          if (psub != null && !psub.trim().isEmpty()) {
+            new JsonArray(psub).forEach(e -> subs.add(e.toString()));
+          }
+          perms.put(pname, subs);
+        });
+        future.complete(perms);
+      } else {
+        future.fail(reply.cause());
+      }
+    });
+    return future;
+  }
+
+  /**
+   * Simple class about permissions cache object.
+   *
+   * @author hji
+   *
+   */
+  public static class PermCache {
+
+    private long timestamp = System.currentTimeMillis();
+    private PgStat pgStat;
+    private Map<String, Set<String>> subPermMap = new HashMap<>();
+
+    public PermCache(PgStat pgStat, Map<String, Set<String>> subPermMap) {
+      this.pgStat = pgStat;
+      this.subPermMap = subPermMap;
+    }
+
+    @Override
+    public String toString() {
+      return "PermCache [timestamp=" + timestamp + ", pgStat=" + pgStat + ", subPermMap=" + subPermMap + "]";
+    }
+
+    public boolean isStale() {
+      return System.currentTimeMillis() > (timestamp + CACHE_PERIOD);
+    }
+
+    public void resetTimeStamp() {
+      this.timestamp = System.currentTimeMillis();
+    }
+
+    public List<String> expandPerms(List<String> perms) {
+      Set<String> allPerms = new HashSet<>();
+      for (String perm : perms) {
+        allPerms.addAll(recurseSub(perm));
+      }
+      return new ArrayList<>(allPerms);
+    }
+
+    private Set<String> recurseSub(String perm) {
+      Set<String> perms = new HashSet<>();
+      perms.add(perm);
+      Set<String> subs = subPermMap.get(perm);
+      if (subs != null) {
+        for (String sub : subs) {
+          perms.addAll(recurseSub(sub));
+        }
+      }
+      return perms;
+    }
+  }
+
+  /**
+   * Simple class about PG_STAT insert, update, and delete info.
+   *
+   * @author hji
+   *
+   */
+  public static class PgStat {
+    private int ins;
+    private int upd;
+    private int del;
+
+    public PgStat(int ins, int upd, int del) {
+      this.ins = ins;
+      this.upd = upd;
+      this.del = del;
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + del;
+      result = prime * result + ins;
+      result = prime * result + upd;
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj)
+        return true;
+      if (obj == null)
+        return false;
+      if (getClass() != obj.getClass())
+        return false;
+      PgStat other = (PgStat) obj;
+      if (del != other.del)
+        return false;
+      if (ins != other.ins)
+        return false;
+      if (upd != other.upd)
+        return false;
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return "PgStat [ins=" + ins + ", upd=" + upd + ", del=" + del + "]";
+    }
+  }
+
+}

--- a/src/main/java/org/folio/rest/impl/PermsCache.java
+++ b/src/main/java/org/folio/rest/impl/PermsCache.java
@@ -11,11 +11,9 @@ import java.util.concurrent.ConcurrentMap;
 
 import org.folio.rest.persist.PostgresClient;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -37,11 +35,6 @@ public class PermsCache {
   private static final String PERMS_PNAME = "p_name";
   private static final String PERMS_PSUB = "p_sub";
 
-  private static final String QUERY_PG_STAT = "select n_tup_ins, n_tup_upd, n_tup_del from pg_stat_user_tables where schemaname = '%s_mod_permissions' and relname = 'permissions'";
-  private static final String PG_STAT_INS = "n_tup_ins";
-  private static final String PG_STAT_UPD = "n_tup_upd";
-  private static final String PG_STAT_DEL = "n_tup_del";
-
   private static final ConcurrentMap<String, PermCache> CACHE = new ConcurrentHashMap<>();
 
   /**
@@ -55,13 +48,12 @@ public class PermsCache {
   public static Future<List<String>> expandPerms(List<String> perms, Context vertxContext, String tenantId) {
     Future<List<String>> future = Future.future();
     PermCache permCache = CACHE.get(tenantId);
-    if (permCache == null) {
+    if (permCache == null || permCache.isStale()) {
       LOGGER.info("Populate perms cache for tenant " + tenantId);
-      Future<PgStat> f1 = queryPermsPgStat(vertxContext, tenantId);
-      Future<Map<String, Set<String>>> f2 = queryAllPerms(vertxContext, tenantId);
-      CompositeFuture.all(f1, f2).setHandler(ar -> {
+      Future<Map<String, Set<String>>> f = queryAllPerms(vertxContext, tenantId);
+      f.setHandler(ar -> {
         if (ar.succeeded()) {
-          PermCache pc = new PermCache(f1.result(), f2.result());
+          PermCache pc = new PermCache(f.result());
           LOGGER.debug("new perms cache: " + pc);
           CACHE.put(tenantId, pc);
           future.complete(pc.expandPerms(perms));
@@ -69,51 +61,9 @@ public class PermsCache {
           future.fail(ar.cause());
         }
       });
-    } else if (permCache.isStale()) {
-      Future<PgStat> f1 = queryPermsPgStat(vertxContext, tenantId);
-      f1.setHandler(ar -> {
-        if (ar.succeeded()) {
-          if (ar.result().equals(permCache.pgStat)) {
-            LOGGER.debug("Reset perm cache timestamp for tenant " + tenantId);
-            permCache.resetTimeStamp();
-            future.complete(permCache.expandPerms(perms));
-          } else {
-            LOGGER.info("Update perms cache for tenant " + tenantId);
-            Future<Map<String, Set<String>>> f2 = queryAllPerms(vertxContext, tenantId);
-            f2.setHandler(ar2 -> {
-              if (ar2.succeeded()) {
-                PermCache pc = new PermCache(f1.result(), f2.result());
-                LOGGER.debug("upated perms cache: " + pc);
-                CACHE.put(tenantId, pc);
-                future.complete(pc.expandPerms(perms));
-              } else {
-                future.fail(ar2.cause());
-              }
-            });
-          }
-        } else {
-          future.fail(ar.cause());
-        }
-      });
     } else {
       future.complete(permCache.expandPerms(perms));
     }
-    return future;
-  }
-
-  private static Future<PgStat> queryPermsPgStat(Context vertxContext, String tenantId) {
-    Future<PgStat> future = Future.future();
-    String query = String.format(QUERY_PG_STAT, tenantId.toLowerCase());
-    PostgresClient pc = PostgresClient.getInstance(vertxContext.owner(), tenantId);
-    pc.select(query, reply -> {
-      if (reply.succeeded()) {
-        JsonObject jo = reply.result().getRows().get(0);
-        PgStat pgStat = new PgStat(jo.getInteger(PG_STAT_INS), jo.getInteger(PG_STAT_UPD), jo.getInteger(PG_STAT_DEL));
-        future.complete(pgStat);
-      } else {
-        future.fail(reply.cause());
-      }
-    });
     return future;
   }
 
@@ -150,17 +100,15 @@ public class PermsCache {
   public static class PermCache {
 
     private long timestamp = System.currentTimeMillis();
-    private PgStat pgStat;
     private Map<String, Set<String>> subPermMap = new HashMap<>();
 
-    public PermCache(PgStat pgStat, Map<String, Set<String>> subPermMap) {
-      this.pgStat = pgStat;
+    public PermCache(Map<String, Set<String>> subPermMap) {
       this.subPermMap = subPermMap;
     }
 
     @Override
     public String toString() {
-      return "PermCache [timestamp=" + timestamp + ", pgStat=" + pgStat + ", subPermMap=" + subPermMap + "]";
+      return "PermCache [timestamp=" + timestamp + ", subPermMap=" + subPermMap + "]";
     }
 
     public boolean isStale() {
@@ -191,56 +139,4 @@ public class PermsCache {
       return perms;
     }
   }
-
-  /**
-   * Simple class about PG_STAT insert, update, and delete info.
-   *
-   * @author hji
-   *
-   */
-  public static class PgStat {
-    private int ins;
-    private int upd;
-    private int del;
-
-    public PgStat(int ins, int upd, int del) {
-      this.ins = ins;
-      this.upd = upd;
-      this.del = del;
-    }
-
-    @Override
-    public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + del;
-      result = prime * result + ins;
-      result = prime * result + upd;
-      return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (this == obj)
-        return true;
-      if (obj == null)
-        return false;
-      if (getClass() != obj.getClass())
-        return false;
-      PgStat other = (PgStat) obj;
-      if (del != other.del)
-        return false;
-      if (ins != other.ins)
-        return false;
-      if (upd != other.upd)
-        return false;
-      return true;
-    }
-
-    @Override
-    public String toString() {
-      return "PgStat [ins=" + ins + ", upd=" + upd + ", del=" + del + "]";
-    }
-  }
-
 }

--- a/src/main/java/org/folio/rest/impl/PermsCache.java
+++ b/src/main/java/org/folio/rest/impl/PermsCache.java
@@ -29,13 +29,16 @@ public class PermsCache {
 
   public static final String CACHE_HEADER = "use.perms.cache";
 
-  private static final long CACHE_PERIOD = 30 * 1000;
+  private static final long CACHE_PERIOD = 30 * 1000L;
 
   private static final String QUERY_PERMS = "select jsonb->>'permissionName' as p_name, jsonb->>'subPermissions' as p_sub from %s_mod_permissions.permissions";
   private static final String PERMS_PNAME = "p_name";
   private static final String PERMS_PSUB = "p_sub";
 
   private static final ConcurrentMap<String, PermCache> CACHE = new ConcurrentHashMap<>();
+
+  private PermsCache() {
+  }
 
   /**
    * Expand permission list to include all sub permissions recursively.
@@ -113,10 +116,6 @@ public class PermsCache {
 
     public boolean isStale() {
       return System.currentTimeMillis() > (timestamp + CACHE_PERIOD);
-    }
-
-    public void resetTimeStamp() {
-      this.timestamp = System.currentTimeMillis();
     }
 
     public List<String> expandPerms(List<String> perms) {

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -10,7 +10,9 @@
       "uniqueIndex" : [
         {
           "fieldName" : "permissionName",
-          "tOps" : "ADD"
+          "tOps" : "ADD",
+          "caseSensitive": true,
+          "removeAccents": false
         }
       ]
     },
@@ -19,7 +21,29 @@
       "generateId" : true,
       "fromModuleVersion" : "5.0",
       "withMetadata" : true,
-      "pkColumnName": "_id"
+      "pkColumnName": "_id",
+      "index" : [
+        {
+          "fieldName" : "id",
+          "tOps" : "ADD",
+          "caseSensitive": true,
+          "removeAccents": false
+        },
+        {
+          "fieldName" : "userId",
+          "tOps" : "ADD",
+          "caseSensitive": true,
+          "removeAccents": false
+        }
+      ],
+      "ginIndex": [
+        {
+          "fieldName": "userId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
     }
   ],
   "views" : []

--- a/src/test/java/org/folio/permstest/PermsCacheTest.java
+++ b/src/test/java/org/folio/permstest/PermsCacheTest.java
@@ -2,7 +2,6 @@ package org.folio.permstest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -13,7 +12,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.folio.rest.impl.PermsCache.PermCache;
-import org.folio.rest.impl.PermsCache.PgStat;
 import org.junit.Test;
 
 public class PermsCacheTest {
@@ -28,16 +26,13 @@ public class PermsCacheTest {
 
   @Test
   public void testPermsCache() {
-    PgStat pgStat = new PgStat(1, 2, 3);
     Map<String, Set<String>> subPermMap = new HashMap<>();
     subPermMap.put(P1, new HashSet<>(Arrays.asList(S1, S2)));
     subPermMap.put(S2, new HashSet<>(Arrays.asList(S21, S22)));
     subPermMap.put(S22, new HashSet<>(Arrays.asList(S221, S222)));
-    PermCache pc = new PermCache(pgStat, subPermMap);
+    PermCache pc = new PermCache(subPermMap);
 
     assertFalse(pc.isStale());
-    assertEquals(new PgStat(1, 2, 3), pgStat);
-    assertNotEquals(new PgStat(2, 2, 3), pgStat);
 
     List<String> rs = pc.expandPerms(Arrays.asList(P1));
     assertEquals(7, rs.size());

--- a/src/test/java/org/folio/permstest/PermsCacheTest.java
+++ b/src/test/java/org/folio/permstest/PermsCacheTest.java
@@ -1,0 +1,60 @@
+package org.folio.permstest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.folio.rest.impl.PermsCache.PermCache;
+import org.folio.rest.impl.PermsCache.PgStat;
+import org.junit.Test;
+
+public class PermsCacheTest {
+
+  private static final String P1 = "perm-1";
+  private static final String S1 = "sub-1";
+  private static final String S2 = "sub-2";
+  private static final String S21 = "sub-2-1";
+  private static final String S22 = "sub-2-2";
+  private static final String S221 = "sub-2-2-1";
+  private static final String S222 = "sub-2-2-2";
+
+  @Test
+  public void testPermsCache() {
+    PgStat pgStat = new PgStat(1, 2, 3);
+    Map<String, Set<String>> subPermMap = new HashMap<>();
+    subPermMap.put(P1, new HashSet<>(Arrays.asList(S1, S2)));
+    subPermMap.put(S2, new HashSet<>(Arrays.asList(S21, S22)));
+    subPermMap.put(S22, new HashSet<>(Arrays.asList(S221, S222)));
+    PermCache pc = new PermCache(pgStat, subPermMap);
+
+    assertFalse(pc.isStale());
+    assertEquals(new PgStat(1, 2, 3), pgStat);
+    assertNotEquals(new PgStat(2, 2, 3), pgStat);
+
+    List<String> rs = pc.expandPerms(Arrays.asList(P1));
+    assertEquals(7, rs.size());
+    assertTrue(rs.contains(P1));
+    assertTrue(rs.contains(S1));
+    assertTrue(rs.contains(S2));
+    assertTrue(rs.contains(S21));
+    assertTrue(rs.contains(S22));
+    assertTrue(rs.contains(S221));
+    assertTrue(rs.contains(S222));
+
+    rs = pc.expandPerms(Arrays.asList(S2));
+    assertEquals(5, rs.size());
+    assertTrue(rs.contains(S2));
+    assertTrue(rs.contains(S21));
+    assertTrue(rs.contains(S22));
+    assertTrue(rs.contains(S221));
+    assertTrue(rs.contains(S222));
+  }
+}

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
+import org.folio.rest.impl.PermsCache;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
@@ -82,7 +83,7 @@ public class RestVerticleTest {
     TenantClient tenantClient = new TenantClient("http://localhost:" + port, "diku", "diku");
     vertx = Vertx.vertx();
     DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject()
-            .put("http.port", port)).setWorker(true);
+            .put("http.port", port).put(PermsCache.CACHE_HEADER, false)).setWorker(true);
     try {
       PostgresClient.setIsEmbedded(true);
       PostgresClient.getInstance(vertx).startEmbeddedPostgres();

--- a/src/test/java/org/folio/permstest/RestVerticleWithCacheTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleWithCacheTest.java
@@ -1,0 +1,184 @@
+package org.folio.permstest;
+
+import org.folio.rest.RestVerticle;
+import org.folio.rest.client.TenantClient;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+
+import io.vertx.core.Future;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.http.HttpMethod;
+import static io.vertx.core.http.HttpMethod.GET;
+import static io.vertx.core.http.HttpMethod.POST;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.LinkedList;
+import java.util.List;
+import org.folio.permstest.TestUtil.WrappedResponse;
+import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+
+@RunWith(VertxUnitRunner.class)
+public class RestVerticleWithCacheTest {
+
+  private static final String userId1 = "35d05a6a-d61e-4e81-9708-fc44daadbec5";
+
+  private static Vertx vertx;
+  static int port;
+
+  @Rule
+  public Timeout rule = Timeout.seconds(180); // 3 minutes for loading embedded postgres
+
+  @BeforeClass
+  public static void setup(TestContext context) {
+    Async async = context.async();
+    port = NetworkUtils.nextFreePort();
+    TenantClient tenantClient = new TenantClient("http://localhost:" + port, "diku", "diku");
+    vertx = Vertx.vertx();
+    DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("http.port", port))
+        .setWorker(true);
+    try {
+      PostgresClient.setIsEmbedded(true);
+      PostgresClient.getInstance(vertx).startEmbeddedPostgres();
+    } catch (Exception e) {
+      e.printStackTrace();
+      context.fail(e);
+      return;
+    }
+    vertx.deployVerticle(RestVerticle.class.getName(), options, res -> {
+      try {
+        TenantAttributes ta = new TenantAttributes();
+        ta.setModuleTo("mod-permissions-1.0.0");
+        List<Parameter> parameters = new LinkedList<>();
+        parameters.add(new Parameter().withKey("loadSample").withValue("true"));
+        ta.setParameters(parameters);
+        tenantClient.postTenant(ta, res2 -> {
+          async.complete();
+        });
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+
+    });
+  }
+
+  @AfterClass
+  public static void teardown(TestContext context) {
+    Async async = context.async();
+    vertx.close(context.asyncAssertSuccess(res -> {
+      PostgresClient.stopEmbeddedPostgres();
+      async.complete();
+    }));
+  }
+
+  @Test
+  public void testPermsSeq(TestContext context) {
+    Async async = context.async();
+    Future<WrappedResponse> startFuture;
+    startFuture = sendPermissionSet(context, false).compose(w -> {
+      return sendPermissionSet(context, true);
+    }).compose(w -> {
+      return postPermUser(context, userId1);
+    }).compose(w -> {
+      return testUserPerms(context, w.getJson().getString("id"));
+    });
+
+    startFuture.setHandler(res -> {
+      if (res.failed()) {
+        context.fail(res.cause());
+      } else {
+        async.complete();
+      }
+    });
+  }
+
+  private Future<WrappedResponse> sendPermissionSet(TestContext context, boolean more) {
+    Future<WrappedResponse> future = Future.future();
+    JsonObject permissionSet = new JsonObject().put("moduleId", "dummy").put("perms",
+        new JsonArray()
+            .add(new JsonObject().put("permissionName", "dummy.read").put("displayName", "Dummy Read")
+                .put("description", "Read Dummy Entries").put("visible", true))
+            .add(new JsonObject().put("permissionName", "dummy.write").put("displayName", "Dummy Write")
+                .put("description", "Write Dummy Entries"))
+            .add(new JsonObject().put("permissionName", "dummy.all").put("displayName", "Dummy All")
+                .put("description", "All Dummy Permissions")
+                .put("subPermissions", new JsonArray().add("dummy.read").add("dummy.write"))));
+
+    if (more) {
+      permissionSet.getJsonArray("perms")
+          .add(new JsonObject().put("permissionName", "dummy.delete").put("displayName", "Dummy Delete")
+              .put("description", "Delete Dummy Entries"))
+          .getJsonObject(2).getJsonArray("subPermissions").add("dummy.delete");
+    }
+    ;
+
+    CaseInsensitiveHeaders headers = new CaseInsensitiveHeaders();
+    headers.add("accept", "application/json,text/plain");
+    TestUtil.doRequest(vertx, "http://localhost:" + port + "/_/tenantpermissions", HttpMethod.POST, headers,
+        permissionSet.encode(), 201).setHandler(res -> {
+          if (res.failed()) {
+            future.fail(res.cause());
+          } else {
+            future.complete(res.result());
+          }
+        });
+
+    return future;
+  }
+
+  private Future<WrappedResponse> postPermUser(TestContext context, String userId) {
+    JsonObject newUser = new JsonObject().put("userId", userId).put("permissions", new JsonArray().add("dummy.all"));
+    Future<WrappedResponse> future = Future.future();
+    TestUtil.doRequest(vertx, "http://localhost:" + port + "/perms/users", POST, null, newUser.encode(), 201)
+        .setHandler(res -> {
+          if (res.failed()) {
+            future.fail(res.cause());
+          } else {
+            future.complete(res.result());
+          }
+        });
+
+    return future;
+  }
+
+  private Future<WrappedResponse> testUserPerms(TestContext context, String permsUserId) {
+    CaseInsensitiveHeaders headers = new CaseInsensitiveHeaders();
+    headers.add("X-Okapi-Permissions", new JsonArray().add("perms.users.get").encode());
+    Future<WrappedResponse> future = Future.future();
+    TestUtil.doRequest(vertx, "http://localhost:" + port + "/perms/users/" + permsUserId + "/permissions?expanded=true",
+        GET, headers, null, 200).setHandler(res -> {
+          try {
+            if (res.failed()) {
+              future.fail(res.cause());
+            } else {
+              JsonArray nameList = res.result().getJson().getJsonArray("permissionNames");
+              if (nameList == null) {
+                future.fail("Could not find 'permissionNames' in " + res.result().getBody());
+              } else {
+                if (nameList.contains("dummy.read") && nameList.contains("dummy.write")) {
+                  future.complete(res.result());
+                } else {
+                  future.fail("Namelist does not contain 'dummy.read' and 'dummy.write' " + "( "
+                      + res.result().getBody() + " )");
+                }
+              }
+            }
+          } catch (Exception e) {
+            future.fail(e);
+          }
+        });
+
+    return future;
+  }
+}


### PR DESCRIPTION
Currently mod-permissions makes many database calls to recursively expand sub permissions. It puts load on database and can be time consuming when the database is busy. Given the relatively static relationship between permissions and sub permissions, this PR retrieves/caches all perms and doing the sub permissions lookup locally.