### PR TITLE
Handle potential empty permission name

### DIFF
--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -912,8 +912,12 @@ public class PermsAPI implements Perms {
         String tenantId = TenantTool.calculateTenantId(okapiHeaders.get(OKAPI_TENANT_HEADER));
         Criteria nameCrit = new Criteria();
         nameCrit.addField(PERMISSION_NAME_FIELD);
-        nameCrit.setOperation("=");
-        nameCrit.setVal(entity.getPermissionName());
+        if (entity.getPermissionName() == null) {
+          nameCrit.setOperation("IS NULL");
+        } else {
+          nameCrit.setOperation("=");
+          nameCrit.setVal(entity.getPermissionName());
+        }
         try {
           PostgresClient.getInstance(vertxContext.owner(), tenantId).get(
             TABLE_NAME_PERMS, Permission.class, new Criterion(nameCrit), true, false, getReply -> {

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -147,6 +147,8 @@ public class RestVerticleTest {
     }).compose(w -> {
       return testPostBadPermission(context);
     }).compose(w -> {
+      return testPostNullPermissionName(context);
+    }).compose(w -> {
       return testPermissionExists(context, "dummy.all");
     }).compose(w -> {
       return sendBadPermissionSet(context);
@@ -1265,6 +1267,20 @@ public class RestVerticleTest {
       );
     TestUtil.doRequest(vertx, "http://localhost:"+port+"/perms/permissions", POST,
             null, badPermission.encode(), 400).setHandler(res -> {
+      if(res.failed()) { future.fail(res.cause()); } else {
+        future.complete(res.result());
+      }
+    });
+
+    return future;
+  }
+
+  private Future<WrappedResponse> testPostNullPermissionName(TestContext context) {
+    Future<WrappedResponse> future = Future.future();
+    JsonObject nullPermission = new JsonObject()
+      .put("displayName", "nullPermName");
+    TestUtil.doRequest(vertx, "http://localhost:"+port+"/perms/permissions", POST,
+            null, nullPermission.encode(), 201).setHandler(res -> {
       if(res.failed()) { future.fail(res.cause()); } else {
         future.complete(res.result());
       }


### PR DESCRIPTION
As reported in MODPERMS-60, with recent update to RMB25, creating permission started to fail if permissionName is not specified. This is due to the refactoring of `wrapVal()` to return empty string for null value, as seen in https://github.com/folio-org/raml-module-builder/blob/v25.0.0/domain-models-runtime/src/main/java/org/folio/rest/persist/Criteria/Criteria.java#L206. This PR is to adjust mod-permission to use `IS NULL` operator rather than `=` operator and `null` val when permission name is null. 