### PR TITLE
Add cache for full permission objects

### DIFF
--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -1705,6 +1705,13 @@ public class PermsAPI implements Perms {
     Context vertxContext, String tenantId) {
     Future<Permission> future = Future.future();
     logger.debug("Getting full permissions for " + permissionName);
+
+    // use cache by default unless set to false explicitly
+    Boolean usePermsCache = vertxContext.config().getBoolean(PermsCache.CACHE_HEADER);
+    if (usePermsCache == null || usePermsCache) {
+      return PermsCache.getFullPerms(permissionName, vertxContext, tenantId);
+    }
+
     try {
       vertxContext.runOnContext(v -> {
         Criteria nameCrit = new Criteria();

--- a/src/main/java/org/folio/rest/impl/PermsCache.java
+++ b/src/main/java/org/folio/rest/impl/PermsCache.java
@@ -9,16 +9,17 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.folio.rest.jaxrs.model.Permission;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.Criteria.Criterion;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
 /**
- * A simple cache to avoid frequent database calls to get sub permissions.
+ * A simple cache to avoid frequent database calls to permissions table.
  *
  * @author hji
  *
@@ -29,13 +30,16 @@ public class PermsCache {
 
   public static final String CACHE_HEADER = "use.perms.cache";
 
+  // 30 seconds cache
   private static final long CACHE_PERIOD = 30 * 1000L;
 
-  private static final String QUERY_PERMS = "select jsonb->>'permissionName' as p_name, jsonb->>'subPermissions' as p_sub from %s_mod_permissions.permissions";
-  private static final String PERMS_PNAME = "p_name";
-  private static final String PERMS_PSUB = "p_sub";
+  private static final String TAB_PERMS = "permissions";
 
+  // store cached data
   private static final ConcurrentMap<String, PermCache> CACHE = new ConcurrentHashMap<>();
+
+  // cache update in progress
+  private static final ConcurrentMap<String, Long> CACHE_WIP = new ConcurrentHashMap<>();
 
   private PermsCache() {
   }
@@ -50,72 +54,107 @@ public class PermsCache {
    */
   public static Future<List<String>> expandPerms(List<String> perms, Context vertxContext, String tenantId) {
     Future<List<String>> future = Future.future();
-    PermCache permCache = CACHE.get(tenantId);
-    if (permCache == null || permCache.isStale()) {
-      LOGGER.info("Populate perms cache for tenant " + tenantId);
-      Future<Map<String, Set<String>>> f = queryAllPerms(vertxContext, tenantId);
-      f.setHandler(ar -> {
-        if (ar.succeeded()) {
-          PermCache pc = new PermCache(f.result());
-          LOGGER.debug("new perms cache: " + pc);
-          CACHE.put(tenantId, pc);
-          future.complete(pc.expandPerms(perms));
-        } else {
-          future.fail(ar.cause());
-        }
-      });
-    } else {
-      future.complete(permCache.expandPerms(perms));
-    }
-    return future;
-  }
-
-  private static Future<Map<String, Set<String>>> queryAllPerms(Context vertxContext, String tenantId) {
-    Future<Map<String, Set<String>>> future = Future.future();
-    String query = String.format(QUERY_PERMS, tenantId.toLowerCase());
-    PostgresClient pc = PostgresClient.getInstance(vertxContext.owner(), tenantId);
-    Map<String, Set<String>> perms = new HashMap<>();
-    pc.select(query, reply -> {
-      if (reply.succeeded()) {
-        reply.result().getRows().forEach(jo -> {
-          String pname = jo.getString(PERMS_PNAME);
-          String psub = jo.getString(PERMS_PSUB);
-          Set<String> subs = new HashSet<>();
-          if (psub != null && !psub.trim().isEmpty()) {
-            new JsonArray(psub).forEach(e -> subs.add(e.toString()));
-          }
-          perms.put(pname, subs);
-        });
-        future.complete(perms);
+    getPermCache(vertxContext, tenantId).setHandler(ar -> {
+      if (ar.succeeded()) {
+        future.complete(ar.result().expandPerms(perms));
       } else {
-        future.fail(reply.cause());
+        future.fail(ar.cause());
       }
     });
     return future;
   }
 
   /**
-   * Simple class about permissions cache object.
+   * Return full {@link Permission} object for given permission name.
    *
-   * @author hji
-   *
+   * @param permissionName
+   * @param vertxContext
+   * @param tenantId
+   * @return
+   */
+  public static Future<Permission> getFullPerms(String permissionName, Context vertxContext, String tenantId) {
+    Future<Permission> future = Future.future();
+    getPermCache(vertxContext, tenantId).setHandler(ar -> {
+      if (ar.succeeded()) {
+        future.complete(ar.result().getFullPerm(permissionName));
+      } else {
+        future.fail(ar.cause());
+      }
+    });
+    return future;
+  }
+
+  private static Future<PermCache> getPermCache(Context vertxContext, String tenantId) {
+    PermCache permCache = CACHE.get(tenantId);
+    if (permCache == null) {
+      LOGGER.info("Populate perms cache for tenant " + tenantId);
+      return refreshCache(vertxContext, tenantId);
+    }
+    if (permCache.isStale() && !CACHE_WIP.containsKey(tenantId)) {
+      CACHE_WIP.put(tenantId, vertxContext.owner().setTimer(1, v -> {
+        LOGGER.info("Refresh perms cache for tenant " + tenantId);
+        refreshCache(vertxContext, tenantId);
+      }));
+    }
+    return Future.succeededFuture(permCache);
+  }
+
+  private static Future<PermCache> refreshCache(Context vertxContext, String tenantId) {
+    Future<PermCache> future = Future.future();
+    PostgresClient.getInstance(vertxContext.owner(), tenantId).get(TAB_PERMS, Permission.class, new Criterion(), false,
+        false, reply -> {
+          if (reply.failed()) {
+            CACHE_WIP.remove(tenantId);
+            String msg = "postgres client 'get' " + TAB_PERMS + " failed: " + reply.cause().getLocalizedMessage();
+            LOGGER.warn(msg);
+            future.fail(msg);
+          } else {
+            List<Permission> perms = reply.result().getResults();
+            Map<String, Set<String>> subPermMap = new HashMap<>();
+            Map<String, Permission> fullPermMap = new HashMap<>();
+            PermCache pc = new PermCache(subPermMap, fullPermMap);
+            for (Permission perm : perms) {
+              fullPermMap.put(perm.getPermissionName(), perm);
+              Set<String> subs = new HashSet<>();
+              if (perm.getSubPermissions() != null && !perm.getSubPermissions().isEmpty()) {
+                perm.getSubPermissions().forEach(e -> subs.add(e.toString()));
+              }
+              subPermMap.put(perm.getPermissionName(), subs);
+            }
+            CACHE.put(tenantId, pc);
+            CACHE_WIP.remove(tenantId);
+            LOGGER.info("Finished perms cache for tenant " + tenantId);
+            future.complete(pc);
+          }
+        });
+    return future;
+  }
+
+  /**
+   * Simple perm cache object.
    */
   public static class PermCache {
 
     private long timestamp = System.currentTimeMillis();
     private Map<String, Set<String>> subPermMap = new HashMap<>();
+    private Map<String, Permission> fullPermMap = new HashMap<>();
 
-    public PermCache(Map<String, Set<String>> subPermMap) {
+    public PermCache(Map<String, Set<String>> subPermMap, Map<String, Permission> fullPermMap) {
       this.subPermMap = subPermMap;
+      this.fullPermMap = fullPermMap;
     }
 
     @Override
     public String toString() {
-      return "PermCache [timestamp=" + timestamp + ", subPermMap=" + subPermMap + "]";
+      return "PermCache [timestamp=" + timestamp + ", subPermMap=" + subPermMap + ", fullPermMap=" + fullPermMap + "]";
     }
 
     public boolean isStale() {
       return System.currentTimeMillis() > (timestamp + CACHE_PERIOD);
+    }
+
+    public Permission getFullPerm(String permName) {
+      return fullPermMap.get(permName);
     }
 
     public List<String> expandPerms(List<String> perms) {

--- a/src/test/java/org/folio/permstest/PermsCacheTest.java
+++ b/src/test/java/org/folio/permstest/PermsCacheTest.java
@@ -15,7 +15,12 @@ import org.folio.rest.impl.PermsCache.PermCache;
 import org.folio.rest.jaxrs.model.Permission;
 import org.junit.Test;
 
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
 public class PermsCacheTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PermsCacheTest.class);
 
   private static final String P1 = "perm-1";
   private static final String S1 = "sub-1";
@@ -35,6 +40,7 @@ public class PermsCacheTest {
     subPermMap.put(S2, new HashSet<>(Arrays.asList(S21, S22)));
     subPermMap.put(S22, new HashSet<>(Arrays.asList(S221, S222)));
     PermCache pc = new PermCache(subPermMap, null);
+    LOGGER.debug(pc.toString());
 
     assertFalse(pc.isStale());
 
@@ -60,10 +66,11 @@ public class PermsCacheTest {
   @Test
   public void testCircularPerms() {
     Map<String, Set<String>> subPermMap = new HashMap<>();
-    subPermMap.put(C1, new HashSet<>(Arrays.asList(C2, P1)));
-    subPermMap.put(C2, new HashSet<>(Arrays.asList(C1, P1)));
+    subPermMap.put(C1, new HashSet<>(Arrays.asList(C1, C2, P1)));
+    subPermMap.put(C2, new HashSet<>(Arrays.asList(C2, C1, P1)));
     subPermMap.put(P1, new HashSet<>(Arrays.asList(S1, S2)));
     PermCache pc = new PermCache(subPermMap, null);
+    LOGGER.debug(pc.toString());
 
     List<String> rs = pc.expandPerms(Arrays.asList(C1));
     assertEquals(5, rs.size());
@@ -82,6 +89,7 @@ public class PermsCacheTest {
     p1.setDisplayName(P1);
     fullPermMap.put(P1, p1);
     PermCache pc = new PermCache(null, fullPermMap);
+    LOGGER.debug(pc.toString());
 
     Permission p = pc.getFullPerm(P1);
     assertEquals(P1, p.getPermissionName());

--- a/src/test/java/org/folio/permstest/PermsCacheTest.java
+++ b/src/test/java/org/folio/permstest/PermsCacheTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.folio.rest.impl.PermsCache.PermCache;
+import org.folio.rest.jaxrs.model.Permission;
 import org.junit.Test;
 
 public class PermsCacheTest {
@@ -33,7 +34,7 @@ public class PermsCacheTest {
     subPermMap.put(P1, new HashSet<>(Arrays.asList(S1, S2)));
     subPermMap.put(S2, new HashSet<>(Arrays.asList(S21, S22)));
     subPermMap.put(S22, new HashSet<>(Arrays.asList(S221, S222)));
-    PermCache pc = new PermCache(subPermMap);
+    PermCache pc = new PermCache(subPermMap, null);
 
     assertFalse(pc.isStale());
 
@@ -62,7 +63,7 @@ public class PermsCacheTest {
     subPermMap.put(C1, new HashSet<>(Arrays.asList(C2, P1)));
     subPermMap.put(C2, new HashSet<>(Arrays.asList(C1, P1)));
     subPermMap.put(P1, new HashSet<>(Arrays.asList(S1, S2)));
-    PermCache pc = new PermCache(subPermMap);
+    PermCache pc = new PermCache(subPermMap, null);
 
     List<String> rs = pc.expandPerms(Arrays.asList(C1));
     assertEquals(5, rs.size());
@@ -71,6 +72,21 @@ public class PermsCacheTest {
     assertTrue(rs.contains(P1));
     assertTrue(rs.contains(S1));
     assertTrue(rs.contains(S2));
+  }
+
+  @Test
+  public void testFulPerms() {
+    Map<String, Permission> fullPermMap = new HashMap<>();
+    Permission p1 = new Permission();
+    p1.setPermissionName(P1);
+    p1.setDisplayName(P1);
+    fullPermMap.put(P1, p1);
+    PermCache pc = new PermCache(null, fullPermMap);
+
+    Permission p = pc.getFullPerm(P1);
+    assertEquals(P1, p.getPermissionName());
+    assertEquals(P1, p.getDisplayName());
+    assertTrue(p.getSubPermissions().isEmpty());
   }
 
 }

--- a/src/test/java/org/folio/permstest/RestVerticleWithCacheTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleWithCacheTest.java
@@ -2,6 +2,7 @@ package org.folio.permstest;
 
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
+import org.folio.rest.impl.PermsCache;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
@@ -46,7 +47,7 @@ public class RestVerticleWithCacheTest {
     port = NetworkUtils.nextFreePort();
     TenantClient tenantClient = new TenantClient("http://localhost:" + port, "diku", "diku");
     vertx = Vertx.vertx();
-    DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("http.port", port))
+    DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("http.port", port).put(PermsCache.CACHE_HEADER, false))
         .setWorker(true);
     try {
       PostgresClient.setIsEmbedded(true);


### PR DESCRIPTION
Cache the whole permission table to speed up the expansion of full permission objects. When the cache is stale, return as is to avoid performance hit to current request, but at the same time use a Vertx 1ms delay timer to trigger off cache refresh. Use a flag to avoid multiple concurrent refresh requests.