### PR TITLE
MODPERMS-68: change perms.users.get from desired to required

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -14,7 +14,7 @@
         {
           "methods": [ "GET" ],
           "pathPattern": "/perms/users*",
-          "permissionsDesired": [ "perms.users.get" ]
+          "permissionsRequired": [ "perms.users.get" ]
         },
         {
           "methods": [ "PUT" ],


### PR DESCRIPTION
Consulted with @kurtnordstrom and @zburke, I changed `perms.users.get` from **desired** to **required**. Tested UI login/checkin/out with admin user, regular user, and also SAML login. All seem fine. To be safe, let's wait a bit before bumping up interface version and making new release.