### PR TITLE
Bump up interface because of new query parameter

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "permissions",
-      "version": "5.2",
+      "version": "5.3",
       "handlers" : [
         {
           "methods": [ "POST" ],


### PR DESCRIPTION
As discussed, bump up **permissions** interface version from current 5.2 to 5.3 because we introduced a new query parameter. See https://github.com/folio-org/mod-permissions/pull/74 and https://issues.folio.org/browse/MODPERMS-79