### PR TITLE
Bump up tenantpermission interface

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -73,7 +73,7 @@
     },
     {
       "id" : "_tenantPermissions",
-      "version" : "1.0",
+      "version" : "1.1",
       "interfaceType" : "system",
       "handlers" : [
         {


### PR DESCRIPTION
As discussed, we also want to bump up **tenantpermission** interface. Okapi can use that to decide if system generated permission sets should be created.