### PR TITLE
Honor id/UUID when posting permission set + refactor MODPERMS-84

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,5 +353,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
+    <generate_routing_context>/perms/users</generate_routing_context>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -128,11 +128,6 @@
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
           <complianceLevel>1.8</complianceLevel>
-          <includes>
-            <include>**/impl/*.java</include>
-            <include>**/*.aj</include>
-          </includes>
-          <aspectDirectory>src/main/java/org/folio/rest/annotations</aspectDirectory>
           <XaddSerialVersionUID>true</XaddSerialVersionUID>
           <showWeaveInfo>true</showWeaveInfo>
           <aspectLibraries>

--- a/ramls/permissions.raml
+++ b/ramls/permissions.raml
@@ -355,6 +355,11 @@ traits:
             body:
               application/json:
                 type: permission
+          400:
+            description: "Bad request"
+            body:
+              text/plain:
+                example: "Bad request"
           404:
             description: "Permission not found"
             body:

--- a/ramls/permissions.raml
+++ b/ramls/permissions.raml
@@ -134,6 +134,11 @@ traits:
             body:
               application/json:
                 type: permissionUser
+          400:
+            description: "Bad request"
+            body:
+              text/plain:
+                example: "Bad request"
           403:
             description: "Access Denied"
             body:

--- a/ramls/permissions.raml
+++ b/ramls/permissions.raml
@@ -184,6 +184,11 @@ traits:
         description: Remove a user
         responses:
           204:
+          400:
+            description: "Bad request"
+            body:
+              text/plain:
+                example: "Bad request"
           404:
             description: "User not found"
             body:
@@ -217,6 +222,11 @@ traits:
               body:
                 application/json:
                   type: permissionNameListObject
+            400:
+              description: "Bad request"
+              body:
+                text/plain:
+                  example: "Bad request"
             403:
               description: "Access Denied"
               body:

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -258,7 +258,7 @@ public class PermsAPI implements Perms {
           new Criterion(idCrit), true, false, queryReply -> {
             if (queryReply.failed()) {
               String errStr = queryReply.cause().getMessage();
-              logger.error(errStr);
+              logger.error(errStr, queryReply.cause());
               asyncResultHandler.handle(Future.succeededFuture(GetPermsUsersByIdResponse.respond400WithTextPlain(errStr)));
               return;
             }
@@ -551,7 +551,7 @@ public class PermsAPI implements Perms {
             try {
               if (getReply.failed()) {
                 String errStr = "Error checking for user: " + getReply.cause().getMessage();
-                logger.error(errStr);
+                logger.error(errStr, getReply.cause());
                 asyncResultHandler.handle(Future.succeededFuture(
                     PostPermsUsersPermissionsByIdResponse.respond400WithTextPlain(errStr)));
                 return;
@@ -692,7 +692,7 @@ public class PermsAPI implements Perms {
           PermissionUser.class, new Criterion(idCrit), true, false, getReply -> {
             if (getReply.failed()) {
               String errStr = getReply.cause().getMessage();
-              logger.error(errStr);
+              logger.error(errStr, getReply.cause());
               asyncResultHandler.handle(Future.succeededFuture(
                   DeletePermsUsersPermissionsByIdAndPermissionnameResponse.respond400WithTextPlain(errStr)));
               return;
@@ -789,7 +789,7 @@ public class PermsAPI implements Perms {
           TABLE_NAME_PERMS, Permission.class, new Criterion(nameCrit), true, false, getReply -> {
             if (getReply.failed()) {
               String errStr = getReply.cause().getMessage();
-              logger.error(errStr);
+              logger.error(errStr, getReply.cause());
               asyncResultHandler.handle(Future.succeededFuture(PostPermsPermissionsResponse.respond400WithTextPlain(errStr)));
               return;
             }
@@ -822,7 +822,8 @@ public class PermsAPI implements Perms {
                 postgresClient.save(connection, TABLE_NAME_PERMS, newId, realPerm, postReply -> {
                   if (postReply.failed()) {
                     postgresClient.rollbackTx(connection, done -> {
-                      logger.error("Unable to save new permission: " + postReply.cause().getMessage());
+                      logger.error("Unable to save new permission: "
+                          + postReply.cause().getMessage(), postReply.cause());
                       asyncResultHandler.handle(Future.succeededFuture(
                           PostPermsPermissionsResponse
                               .respond500WithTextPlain(getInternalError(postReply.cause().getMessage()))));
@@ -879,7 +880,7 @@ public class PermsAPI implements Perms {
           .get(TABLE_NAME_PERMS, Permission.class, new Criterion(idCrit), true, false, getReply -> {
             if (getReply.failed()) {
               String errStr = getReply.cause().getMessage();
-              logger.error(errStr);
+              logger.error(errStr, getReply.cause());
               asyncResultHandler.handle(Future.succeededFuture(
                   GetPermsPermissionsByIdResponse.respond400WithTextPlain(errStr)));
               return;
@@ -1700,7 +1701,9 @@ public class PermsAPI implements Perms {
     CompositeFuture compositeFuture = CompositeFuture.join(futureList);
     compositeFuture.onComplete(compositeResult -> {
       if (compositeResult.failed()) {
-        logger.error("Failed to expand subpermissions for '" + permission.getPermissionName() + "' : " + compositeResult.cause().getMessage());
+        logger.error("Failed to expand subpermissions for '" + permission.getPermissionName()
+                + "' : " + compositeResult.cause().getMessage(),
+            compositeResult.cause());
         promise.fail(compositeResult.cause().getMessage());
         return;
       }

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -420,7 +420,7 @@ public class PermsAPI implements Perms {
                 //rollback, 404
                 pgClient.rollbackTx(connection, rollback -> {
                   asyncResultHandler.handle(Future.succeededFuture(
-                      DeletePermsUsersByIdResponse.respond404WithTextPlain("Not found")));
+                      DeletePermsUsersByIdResponse.respond404WithTextPlain(userid)));
                 });
                 return;
               }
@@ -454,8 +454,7 @@ public class PermsAPI implements Perms {
                         if (deleteReply.result().rowCount() == 0) {
                           pgClient.rollbackTx(connection, rollback -> {
                             asyncResultHandler.handle(Future.succeededFuture(
-                                DeletePermsUsersByIdResponse.respond404WithTextPlain(
-                                    "Not found")));
+                                DeletePermsUsersByIdResponse.respond404WithTextPlain(userid)));
                           });
                           return;
                         }
@@ -1032,8 +1031,7 @@ public class PermsAPI implements Perms {
             List<Permission> permList = getReply.result().getResults();
             if (permList.isEmpty()) {
               asyncResultHandler.handle(Future.succeededFuture(
-                  DeletePermsPermissionsByIdResponse
-                      .respond404WithTextPlain("Not found")));
+                  DeletePermsPermissionsByIdResponse.respond404WithTextPlain(id)));
               return;
             }
             Permission perm = permList.get(0);
@@ -1108,7 +1106,7 @@ public class PermsAPI implements Perms {
                     return;
                   }
                   if (deleteReply.result().rowCount() == 0) {
-                    asyncResultHandler.handle(Future.succeededFuture(DeletePermsPermissionsByIdResponse.respond404WithTextPlain("Not found")));
+                    asyncResultHandler.handle(Future.succeededFuture(DeletePermsPermissionsByIdResponse.respond404WithTextPlain(id)));
                     return;
                   }
                   asyncResultHandler.handle(Future.succeededFuture(DeletePermsPermissionsByIdResponse.respond204()));

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -101,6 +101,7 @@ public class PermsAPI implements Perms {
   private static final String USER_NAME_FIELD = "'username'";
   private static final String USER_ID_FIELD = "'userId'";
   private static final String ID_FIELD = "'id'";
+  private static final String UNABLE_TO_UPDATE_DERIVED_FIELDS = "Unable to update derived fields: ";
   protected static final String PERMISSION_NAME_FIELD = "'permissionName'";
   private final Logger logger = LoggerFactory.getLogger(PermsAPI.class);
   private static boolean suppressErrorResponse = false;
@@ -213,7 +214,7 @@ public class PermsAPI implements Perms {
                               PostPermsUsersResponse.respond422WithApplicationJson(
                                   ValidationHelper.createValidationErrorMessage(
                                       ID_FIELD, permUser.getId(),
-                                      "Unable to update derived fields: " + updatePermsRes.cause().getMessage()))));
+                                      UNABLE_TO_UPDATE_DERIVED_FIELDS + updatePermsRes.cause().getMessage()))));
                         } else {
                           asyncResultHandler.handle(Future.succeededFuture(
                               PostPermsUsersResponse.respond500WithTextPlain(
@@ -357,8 +358,7 @@ public class PermsAPI implements Perms {
                               PutPermsUsersByIdResponse.respond422WithApplicationJson(
                                   ValidationHelper.createValidationErrorMessage(
                                       ID_FIELD, entity.getId(),
-                                          "Unable to update derived fields: "
-                                              + updateUserPermsRes.cause().getMessage()))));
+                                          UNABLE_TO_UPDATE_DERIVED_FIELDS + updateUserPermsRes.cause().getMessage()))));
                         } else {
                           String errStr = "Error with derived field update: " + updateUserPermsRes.cause().getMessage();
                           logger.error(errStr, updateUserPermsRes.cause());
@@ -967,8 +967,7 @@ public class PermsAPI implements Perms {
                                       PutPermsPermissionsByIdResponse.respond422WithApplicationJson(
                                           ValidationHelper.createValidationErrorMessage(
                                               ID_FIELD, entity.getId(),
-                                              "Unable to update derived fields: "
-                                                      + updateSubPermsRes.cause().getMessage()))));
+                                              UNABLE_TO_UPDATE_DERIVED_FIELDS + updateSubPermsRes.cause().getMessage()))));
                                 } else {
                                   String errStr = "Error with derived field update: "
                                       + updateSubPermsRes.cause().getMessage();

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -411,7 +411,7 @@ public class PermsAPI implements Perms {
                       getReply.cause().getMessage());
                   logger.error(errStr, getReply.cause());
                   asyncResultHandler.handle(Future.succeededFuture(
-                      DeletePermsUsersByIdResponse.respond500WithTextPlain(getErrorResponse(errStr))));
+                      DeletePermsUsersByIdResponse.respond400WithTextPlain(errStr)));
                 });
                 return;
               }
@@ -512,12 +512,10 @@ public class PermsAPI implements Perms {
 
       pnloFuture.onComplete(res -> {
         if (res.failed()) {
-          String errStr = "Error from get reply: " + res.cause()
-              .getMessage();
+          String errStr = res.cause().getMessage();
           logger.error(errStr, res.cause());
           asyncResultHandler.handle(Future.succeededFuture(
-              GetPermsUsersPermissionsByIdResponse
-                  .respond500WithTextPlain(getErrorResponse(errStr))));
+              GetPermsUsersPermissionsByIdResponse.respond400WithTextPlain(errStr)));
           return;
         }
         PermissionNameListObject pnlo = res.result();
@@ -551,11 +549,10 @@ public class PermsAPI implements Perms {
           getReply -> {
             try {
               if (getReply.failed()) {
-                logger.error("Error checking for user: " + getReply.cause()
-                    .getMessage(), getReply.cause());
+                String errStr = "Error checking for user: " + getReply.cause().getMessage();
+                logger.error(errStr);
                 asyncResultHandler.handle(Future.succeededFuture(
-                    PostPermsUsersPermissionsByIdResponse
-                        .respond500WithTextPlain("Internal server error")));
+                    PostPermsUsersPermissionsByIdResponse.respond400WithTextPlain(errStr)));
                 return;
               }
               List<PermissionUser> userList = getReply.result().getResults();
@@ -697,9 +694,10 @@ public class PermsAPI implements Perms {
       PostgresClient.getInstance(vertxContext.owner(), tenantId).get(TABLE_NAME_PERMSUSERS,
           PermissionUser.class, new Criterion(idCrit), true, false, getReply -> {
             if (getReply.failed()) {
-              logger.error("Error checking for user: " + getReply.cause().getMessage());
+              String errStr = getReply.cause().getMessage();
+              logger.error(errStr);
               asyncResultHandler.handle(Future.succeededFuture(
-                  DeletePermsUsersPermissionsByIdAndPermissionnameResponse.respond500WithTextPlain("Internal server error")));
+                  DeletePermsUsersPermissionsByIdAndPermissionnameResponse.respond400WithTextPlain(errStr)));
               return;
             }
             List<PermissionUser> userList = getReply.result().getResults();
@@ -788,8 +786,9 @@ public class PermsAPI implements Perms {
       PostgresClient.getInstance(vertxContext.owner(), tenantId).get(
           TABLE_NAME_PERMS, Permission.class, new Criterion(nameCrit), true, false, getReply -> {
             if (getReply.failed()) {
-              logger.error("Error getting existing permissions: " + getReply.cause().getMessage());
-              asyncResultHandler.handle(Future.succeededFuture(PostPermsPermissionsResponse.respond500WithTextPlain("Internal server error")));
+              String errStr = getReply.cause().getMessage();
+              logger.error(errStr);
+              asyncResultHandler.handle(Future.succeededFuture(PostPermsPermissionsResponse.respond400WithTextPlain(errStr)));
               return;
             }
             List<Permission> permissionList = getReply.result().getResults();
@@ -919,14 +918,14 @@ public class PermsAPI implements Perms {
           TABLE_NAME_PERMS, Permission.class, new Criterion(idCrit),
           true, false, getReply -> {
             if (getReply.failed()) {
-              String message = "Error with get: " + getReply.cause().getMessage();
+              String message = getReply.cause().getMessage();
               logger.error(message, getReply.cause());
               asyncResultHandler.handle(Future.succeededFuture(
-                  PutPermsPermissionsByIdResponse.respond500WithTextPlain(getErrorResponse(message))));
+                  PutPermsPermissionsByIdResponse.respond400WithTextPlain(message)));
               return;
             }
             List<Permission> permList = getReply.result().getResults();
-            if (permList.size() < 1) {
+            if (permList.isEmpty()) {
               String message = "No permission found to match that id";
               asyncResultHandler.handle(Future.succeededFuture(
                   PutPermsPermissionsByIdResponse.respond404WithTextPlain(message)));
@@ -1024,8 +1023,7 @@ public class PermsAPI implements Perms {
               String errStr = getReply.cause().getMessage();
               logger.error(errStr, getReply.cause());
               asyncResultHandler.handle(Future.succeededFuture(
-                  DeletePermsPermissionsByIdResponse.respond500WithTextPlain(
-                      getErrorResponse(errStr))));
+                  DeletePermsPermissionsByIdResponse.respond400WithTextPlain(errStr)));
               return;
             }
             List<Permission> permList = getReply.result().getResults();

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Permission;
 import org.folio.rest.jaxrs.model.PermissionListObject;
 import org.folio.rest.jaxrs.model.PermissionNameListObject;
@@ -137,6 +138,7 @@ public class PermsAPI implements Perms {
     }
   }
 
+  @Validate
   @Override
   public void getPermsUsers(int length, int start, String sortBy, String query,
                             String hasPermissions, RoutingContext routingContext, Map<String, String> okapiHeaders,
@@ -146,6 +148,7 @@ public class PermsAPI implements Perms {
         routingContext, okapiHeaders, vertxContext);
   }
 
+  @Validate
   @Override
   public void postPermsUsers(PermissionUser entity, RoutingContext routingContext, Map<String, String> okapiHeaders,
                              Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -244,6 +247,7 @@ public class PermsAPI implements Perms {
     }
   }
 
+  @Validate
   @Override
   public void getPermsUsersById(String id, String indexField, Map<String, String> okapiHeaders,
                                 Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -272,6 +276,7 @@ public class PermsAPI implements Perms {
     }
   }
 
+  @Validate
   @Override
   public void putPermsUsersById(String userid, PermissionUser entity, Map<String, String> okapiHeaders,
                                 Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -385,6 +390,7 @@ public class PermsAPI implements Perms {
     };
   }
 
+  @Validate
   @Override
   public void deletePermsUsersById(String userid, Map<String, String> okapiHeaders,
                                    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -479,6 +485,7 @@ public class PermsAPI implements Perms {
     }
   }
 
+  @Validate
   @Override
   public void getPermsUsersPermissionsById(String id, String expanded,
                                            String full, String indexField, Map<String, String> okapiHeaders,
@@ -528,6 +535,7 @@ public class PermsAPI implements Perms {
     }
   }
 
+  @Validate
   @Override
   public void postPermsUsersPermissionsById(String id, String indexField,
                                             PermissionNameObject entity, Map<String, String> okapiHeaders,
@@ -671,6 +679,7 @@ public class PermsAPI implements Perms {
     }
   }
 
+  @Validate
   @Override
   public void deletePermsUsersPermissionsByIdAndPermissionname(
       String id, String permissionname,
@@ -762,6 +771,7 @@ public class PermsAPI implements Perms {
     }
   }
 
+  @Validate
   @Override
   public void postPermsPermissions(PermissionUpload entity, Map<String, String> okapiHeaders,
                                    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -854,6 +864,7 @@ public class PermsAPI implements Perms {
     }
   }
 
+  @Validate
   @Override
   public void getPermsPermissionsById(String id, Map<String, String> okapiHeaders,
                                       Handler<AsyncResult<Response>> asyncResultHandler,
@@ -889,6 +900,7 @@ public class PermsAPI implements Perms {
     }
   }
 
+  @Validate
   @Override
   public void putPermsPermissionsById(String id, PermissionUpload entity,
                                       Map<String, String> okapiHeaders,
@@ -1000,6 +1012,7 @@ public class PermsAPI implements Perms {
     }
   }
 
+  @Validate
   @Override
   public void deletePermsPermissionsById(String id,
                                          Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
@@ -1120,6 +1133,7 @@ public class PermsAPI implements Perms {
   }
 
   @SuppressWarnings("java:S3776")
+  @Validate
   @Override
   public void getPermsPermissions(String expandSubs, String expanded, String includeDummy,
                                   int length, int start, String sortBy, String query, String memberOf,

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -291,15 +291,11 @@ public class PermsAPI implements Perms {
                         "Cannot add permissions flagged as 'dummy' to users")));
                 return;
               }
-              Criteria idCrit = new Criteria();
-              idCrit.addField(ID_FIELD);
-              idCrit.setOperation("=");
-              idCrit.setVal(userid);
               String query = "id==" + userid;
               CQLWrapper cqlFilter = getCQL(query, TABLE_NAME_PERMSUSERS);
 
               PostgresClient.getInstance(vertxContext.owner(), tenantId).get(
-                  TABLE_NAME_PERMSUSERS, PermissionUser.class, new Criterion(idCrit), true, false,
+                  TABLE_NAME_PERMSUSERS, PermissionUser.class, cqlFilter, true,
                   putPermsUsersbyIdHandle(userid, entity, asyncResultHandler, vertxContext, tenantId, cqlFilter));
             } catch (Exception e) {
               logger.error(e.getMessage(), e);

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -251,9 +251,9 @@ public class PermsAPI implements Perms {
       PostgresClient.getInstance(vertxContext.owner(), tenantId).get(TABLE_NAME_PERMSUSERS, PermissionUser.class,
           new Criterion(idCrit), true, false, queryReply -> {
             if (queryReply.failed()) {
-              String errStr = "queryReply failed: " + queryReply.cause().getMessage();
+              String errStr = queryReply.cause().getMessage();
               logger.error(errStr);
-              asyncResultHandler.handle(Future.succeededFuture(GetPermsUsersByIdResponse.respond500WithTextPlain(getErrorResponse(errStr))));
+              asyncResultHandler.handle(Future.succeededFuture(GetPermsUsersByIdResponse.respond400WithTextPlain(errStr)));
               return;
             }
             List<PermissionUser> userList = queryReply.result().getResults();

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -119,7 +119,7 @@ public class PermsAPI implements Perms {
 
   private final Messages messages = Messages.getInstance();
 
-  private String getErrorResponse(String response) {
+  private String getInternalError(String response) {
     if (suppressErrorResponse) {
       return "Internal Server Error: Please contact Admin";
     }
@@ -212,12 +212,12 @@ public class PermsAPI implements Perms {
                           asyncResultHandler.handle(Future.succeededFuture(
                               PostPermsUsersResponse.respond422WithApplicationJson(
                                   ValidationHelper.createValidationErrorMessage(
-                                      ID_FIELD, permUser.getId(), getErrorResponse(
-                                          "Unable to update derived fields: " + updatePermsRes.cause().getMessage())))));
+                                      ID_FIELD, permUser.getId(),
+                                      "Unable to update derived fields: " + updatePermsRes.cause().getMessage()))));
                         } else {
                           asyncResultHandler.handle(Future.succeededFuture(
                               PostPermsUsersResponse.respond500WithTextPlain(
-                                  getErrorResponse(updatePermsRes.cause().getMessage()))));
+                                  getInternalError(updatePermsRes.cause().getMessage()))));
                         }
                       });
                       return;
@@ -230,7 +230,8 @@ public class PermsAPI implements Perms {
                 } catch (Exception e) {
                   String errStr = "Error saving entity " + entity.toString() + ": " + e.getMessage();
                   logger.error(errStr, e);
-                  asyncResultHandler.handle(Future.succeededFuture(PostPermsUsersResponse.respond500WithTextPlain(getErrorResponse(errStr))));
+                  asyncResultHandler.handle(Future.succeededFuture(
+                      PostPermsUsersResponse.respond500WithTextPlain(getInternalError(errStr))));
                 }
               });
             });
@@ -238,13 +239,13 @@ public class PermsAPI implements Perms {
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
       asyncResultHandler.handle(Future.succeededFuture(
-          PostPermsUsersResponse.respond500WithTextPlain(getErrorResponse(e.getMessage()))));
+          PostPermsUsersResponse.respond500WithTextPlain(getInternalError(e.getMessage()))));
     }
   }
 
   @Override
-  public void getPermsUsersById(String id, String indexField, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
-                                Context vertxContext) {
+  public void getPermsUsersById(String id, String indexField, Map<String, String> okapiHeaders,
+                                Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     try {
       String tenantId = TenantTool.tenantId(okapiHeaders);
       Criteria idCrit = getIdCriteria(indexField, "=", id);
@@ -266,7 +267,7 @@ public class PermsAPI implements Perms {
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
       asyncResultHandler.handle(Future.succeededFuture(
-          GetPermsUsersByIdResponse.respond500WithTextPlain(getErrorResponse(e.getMessage()))));
+          GetPermsUsersByIdResponse.respond500WithTextPlain(getInternalError(e.getMessage()))));
     }
   }
 
@@ -300,13 +301,13 @@ public class PermsAPI implements Perms {
             } catch (Exception e) {
               logger.error(e.getMessage(), e);
               asyncResultHandler.handle(Future.succeededFuture(
-                  PutPermsUsersByIdResponse.respond500WithTextPlain(getErrorResponse(e.getMessage()))));
+                  PutPermsUsersByIdResponse.respond500WithTextPlain(getInternalError(e.getMessage()))));
             }
           });
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
       asyncResultHandler.handle(
-          Future.succeededFuture(PutPermsUsersByIdResponse.respond500WithTextPlain(getErrorResponse(e.getMessage()))));
+          Future.succeededFuture(PutPermsUsersByIdResponse.respond500WithTextPlain(getInternalError(e.getMessage()))));
     }
   }
 
@@ -319,7 +320,7 @@ public class PermsAPI implements Perms {
         String errStr = getReply.cause().getMessage();
         logger.error(errStr, getReply.cause());
         asyncResultHandler.handle(Future.succeededFuture(
-            PutPermsUsersByIdResponse.respond500WithTextPlain(getErrorResponse(errStr))));
+            PutPermsUsersByIdResponse.respond500WithTextPlain(getInternalError(errStr))));
       } else {
         List<PermissionUser> userList = getReply.result().getResults();
         if (userList.isEmpty()) {
@@ -341,7 +342,7 @@ public class PermsAPI implements Perms {
                           + updateReply.cause().getMessage();
                       logger.error(errStr, updateReply.cause());
                       asyncResultHandler.handle(Future.succeededFuture(
-                          PutPermsUsersByIdResponse.respond500WithTextPlain(getErrorResponse(errStr))));
+                          PutPermsUsersByIdResponse.respond500WithTextPlain(getInternalError(errStr))));
                     });
                     return;
                   }
@@ -355,14 +356,14 @@ public class PermsAPI implements Perms {
                           asyncResultHandler.handle(Future.succeededFuture(
                               PutPermsUsersByIdResponse.respond422WithApplicationJson(
                                   ValidationHelper.createValidationErrorMessage(
-                                      ID_FIELD, entity.getId(), getErrorResponse(
+                                      ID_FIELD, entity.getId(),
                                           "Unable to update derived fields: "
-                                              + updateUserPermsRes.cause().getMessage())))));
+                                              + updateUserPermsRes.cause().getMessage()))));
                         } else {
                           String errStr = "Error with derived field update: " + updateUserPermsRes.cause().getMessage();
                           logger.error(errStr, updateUserPermsRes.cause());
                           asyncResultHandler.handle(Future.succeededFuture(
-                              PutPermsUsersByIdResponse.respond500WithTextPlain(getErrorResponse(errStr))));
+                              PutPermsUsersByIdResponse.respond500WithTextPlain(getInternalError(errStr))));
                         }
                       });
                     } else {
@@ -376,11 +377,9 @@ public class PermsAPI implements Perms {
                 });
           });
         } catch (Exception e) {
-          String errStr = "Error using Postgres instance: "
-              + e.getMessage();
-          logger.error(errStr, e);
+          logger.error(e.getMessage(), e);
           asyncResultHandler.handle(Future.succeededFuture(
-              PutPermsUsersByIdResponse.respond500WithTextPlain(getErrorResponse(errStr))));
+              PutPermsUsersByIdResponse.respond500WithTextPlain(getInternalError(e.getMessage()))));
         }
       }
     };
@@ -431,7 +430,7 @@ public class PermsAPI implements Perms {
                           updateUserPermsRes.cause().getMessage());
                       logger.error(errStr, updateUserPermsRes.cause());
                       asyncResultHandler.handle(Future.succeededFuture(
-                          DeletePermsUsersByIdResponse.respond500WithTextPlain(getErrorResponse(errStr))));
+                          DeletePermsUsersByIdResponse.respond500WithTextPlain(getInternalError(errStr))));
                     });
                     return;
                   }
@@ -443,7 +442,7 @@ public class PermsAPI implements Perms {
                                 deleteReply.cause().getMessage());
                             logger.error(errStr, deleteReply.cause());
                             asyncResultHandler.handle(Future.succeededFuture(
-                                DeletePermsUsersByIdResponse.respond500WithTextPlain(getErrorResponse(errStr))));
+                                DeletePermsUsersByIdResponse.respond500WithTextPlain(getInternalError(errStr))));
                           });
                           return;
                         }
@@ -467,8 +466,7 @@ public class PermsAPI implements Perms {
                       e.getMessage());
                   logger.error(errStr, e);
                   asyncResultHandler.handle(Future.succeededFuture(
-                      DeletePermsUsersByIdResponse.respond500WithTextPlain(
-                          getErrorResponse(errStr))));
+                      DeletePermsUsersByIdResponse.respond500WithTextPlain(getInternalError(errStr))));
                 });
               }
             });
@@ -477,8 +475,7 @@ public class PermsAPI implements Perms {
       String errStr = "Error using Postgres instance: " + e.getMessage();
       logger.error(errStr, e);
       asyncResultHandler.handle(Future.succeededFuture(
-          DeletePermsUsersByIdResponse.respond500WithTextPlain(
-              getErrorResponse(errStr))));
+          DeletePermsUsersByIdResponse.respond500WithTextPlain(getInternalError(errStr))));
     }
   }
 
@@ -525,9 +522,9 @@ public class PermsAPI implements Perms {
         }
       });
     } catch (Exception e) {
-      String errStr = "Error running on vertx context: " + e.getMessage();
-      logger.debug(errStr);
-      asyncResultHandler.handle(Future.succeededFuture(GetPermsUsersPermissionsByIdResponse.respond500WithTextPlain(getErrorResponse(errStr))));
+      logger.error(e.getMessage(), e);
+      asyncResultHandler.handle(Future.succeededFuture(
+          GetPermsUsersPermissionsByIdResponse.respond500WithTextPlain(getInternalError(e.getMessage()))));
     }
   }
 
@@ -582,8 +579,7 @@ public class PermsAPI implements Perms {
                       logger.error(errStr, rpbnRes.cause());
                       asyncResultHandler.handle(Future.succeededFuture(
                           PostPermsUsersPermissionsByIdResponse
-                              .respond500WithTextPlain(getErrorResponse(
-                                  errStr))));
+                              .respond500WithTextPlain(getInternalError(errStr))));
                       return;
                     }
                     if (rpbnRes.result() == null) {
@@ -618,8 +614,7 @@ public class PermsAPI implements Perms {
                                   logger.error(errStr, putReply.cause());
                                   asyncResultHandler.handle(Future.succeededFuture(
                                       PostPermsUsersPermissionsByIdResponse
-                                          .respond500WithTextPlain(
-                                              getErrorResponse(errStr))));
+                                          .respond500WithTextPlain(getInternalError(errStr))));
                                 });
                                 return;
                               }
@@ -636,8 +631,7 @@ public class PermsAPI implements Perms {
                                     logger.error(errStr, updateUserPermsRes.cause());
                                     asyncResultHandler.handle(Future.succeededFuture(
                                         PostPermsUsersPermissionsByIdResponse
-                                            .respond500WithTextPlain(
-                                                getErrorResponse(errStr))));
+                                            .respond500WithTextPlain(getInternalError(errStr))));
                                   });
                                   return;
                                 }
@@ -653,12 +647,10 @@ public class PermsAPI implements Perms {
                             });
                       });
                     } catch (Exception e) {
-                      logger.error("Error using Postgres instance to update user: "
-                          + e.getMessage());
+                      logger.error(e.getMessage(), e);
                       asyncResultHandler.handle(Future.succeededFuture(
                           PostPermsUsersPermissionsByIdResponse
-                              .respond500WithTextPlain(
-                                  "Internal server error")));
+                              .respond500WithTextPlain(getInternalError(e.getMessage()))));
                     }
                   });
 
@@ -729,7 +721,7 @@ public class PermsAPI implements Perms {
                           logger.error(errStr, putReply.cause());
                           asyncResultHandler.handle(Future.succeededFuture(
                               DeletePermsUsersPermissionsByIdAndPermissionnameResponse
-                                  .respond500WithTextPlain(getErrorResponse(errStr))));
+                                  .respond500WithTextPlain(getInternalError(errStr))));
                         });
                         return;
                       }
@@ -744,7 +736,7 @@ public class PermsAPI implements Perms {
                             logger.error(errStr, updateUserPermsRes.cause());
                             asyncResultHandler.handle(Future.succeededFuture(
                                 DeletePermsUsersPermissionsByIdAndPermissionnameResponse
-                                    .respond500WithTextPlain(getErrorResponse(errStr))));
+                                    .respond500WithTextPlain(getInternalError(errStr))));
                           });
                           return;
                         }
@@ -756,13 +748,17 @@ public class PermsAPI implements Perms {
                     });
               });
             } catch (Exception e) {
-              logger.error("Error using Postgres instance to delete permission from user");
-              asyncResultHandler.handle(Future.succeededFuture(DeletePermsUsersPermissionsByIdAndPermissionnameResponse.respond500WithTextPlain("Internal server error")));
+              logger.error(e.getMessage(), e);
+              asyncResultHandler.handle(Future.succeededFuture(
+                  DeletePermsUsersPermissionsByIdAndPermissionnameResponse.respond500WithTextPlain(
+                      getInternalError(e.getMessage()))));
             }
           });
     } catch (Exception e) {
-      logger.error("Error using Postgres instance to retrieve user: " + e.getMessage());
-      asyncResultHandler.handle(Future.succeededFuture(DeletePermsUsersPermissionsByIdAndPermissionnameResponse.respond500WithTextPlain("Internal server error")));
+      logger.error(e.getMessage(), e);
+      asyncResultHandler.handle(Future.succeededFuture(
+          DeletePermsUsersPermissionsByIdAndPermissionnameResponse.respond500WithTextPlain(
+              getInternalError(e.getMessage()))));
     }
   }
 
@@ -817,7 +813,9 @@ public class PermsAPI implements Perms {
                   if (postReply.failed()) {
                     postgresClient.rollbackTx(connection, done -> {
                       logger.error("Unable to save new permission: " + postReply.cause().getMessage());
-                      asyncResultHandler.handle(Future.succeededFuture(PostPermsPermissionsResponse.respond500WithTextPlain("Internal server error")));
+                      asyncResultHandler.handle(Future.succeededFuture(
+                          PostPermsPermissionsResponse
+                              .respond500WithTextPlain(getInternalError(postReply.cause().getMessage()))));
                     });
                     return;
                   }
@@ -842,19 +840,17 @@ public class PermsAPI implements Perms {
                 });
               } catch (Exception e) {
                 postgresClient.rollbackTx(connection, done -> {
-                  logger.error("Error with Postgres client while saving permission: "
-                      + e.getMessage());
+                  logger.error(e.getMessage(), e);
                   asyncResultHandler.handle(Future.succeededFuture(
-                      PostPermsPermissionsResponse
-                          .respond500WithTextPlain("Internal server error")));
+                      PostPermsPermissionsResponse.respond500WithTextPlain(getInternalError(e.getMessage()))));
                 });
-
               }
             });
           });
     } catch (Exception e) {
-      logger.error("Error calling Postgresclient: " + e.getMessage());
-      asyncResultHandler.handle(Future.succeededFuture(PostPermsPermissionsResponse.respond500WithTextPlain("Internal server error")));
+      logger.error(e.getMessage(), e);
+      asyncResultHandler.handle(Future.succeededFuture(
+          PostPermsPermissionsResponse.respond500WithTextPlain(getInternalError(e.getMessage()))));
     }
   }
 
@@ -879,14 +875,17 @@ public class PermsAPI implements Perms {
             }
             List<Permission> permList = getReply.result().getResults();
             if (permList.isEmpty()) {
-              asyncResultHandler.handle(Future.succeededFuture(GetPermsPermissionsByIdResponse.respond404WithTextPlain("No permission with ID " + id + " exists")));
+              asyncResultHandler.handle(Future.succeededFuture(
+                  GetPermsPermissionsByIdResponse.respond404WithTextPlain("No permission with ID " + id + " exists")));
               return;
             }
-            asyncResultHandler.handle(Future.succeededFuture(GetPermsPermissionsByIdResponse.respond200WithApplicationJson(permList.get(0))));
+            asyncResultHandler.handle(Future.succeededFuture(
+                GetPermsPermissionsByIdResponse.respond200WithApplicationJson(permList.get(0))));
           });
     } catch (Exception e) {
-      logger.error("Error getting Permission with Postgres client: " + e.getMessage());
-      asyncResultHandler.handle(Future.succeededFuture(GetPermsPermissionsByIdResponse.respond500WithTextPlain("Internal server error")));
+      logger.error(e.getMessage(), e);
+      asyncResultHandler.handle(Future.succeededFuture(
+          GetPermsPermissionsByIdResponse.respond500WithTextPlain(getInternalError(e.getMessage()))));
     }
   }
 
@@ -952,7 +951,7 @@ public class PermsAPI implements Perms {
                           logger.error("Error with put: " + putReply.cause().getMessage(), putReply.cause());
                           asyncResultHandler.handle(Future.succeededFuture(
                               PutPermsPermissionsByIdResponse.respond500WithTextPlain(
-                                  "Internal server error")));
+                                  getInternalError(putReply.cause().getMessage()))));
                         });
                         return;
                       }
@@ -967,16 +966,16 @@ public class PermsAPI implements Perms {
                                   asyncResultHandler.handle(Future.succeededFuture(
                                       PutPermsPermissionsByIdResponse.respond422WithApplicationJson(
                                           ValidationHelper.createValidationErrorMessage(
-                                              ID_FIELD, entity.getId(), getErrorResponse(
-                                                  "Unable to update derived fields: "
-                                                      + updateSubPermsRes.cause().getMessage())))));
+                                              ID_FIELD, entity.getId(),
+                                              "Unable to update derived fields: "
+                                                      + updateSubPermsRes.cause().getMessage()))));
                                 } else {
                                   String errStr = "Error with derived field update: "
                                       + updateSubPermsRes.cause().getMessage();
                                   logger.error(errStr, updateSubPermsRes.cause());
                                   asyncResultHandler.handle(Future.succeededFuture(
                                       PutPermsPermissionsByIdResponse.respond500WithTextPlain(
-                                          getErrorResponse(errStr))));
+                                          getInternalError(errStr))));
                                 }
                               });
                               return;
@@ -990,13 +989,15 @@ public class PermsAPI implements Perms {
                     });
               });
             } catch (Exception e) {
-              logger.error("Error using Postgres instance: " + e.getMessage());
-              asyncResultHandler.handle(Future.succeededFuture(PutPermsPermissionsByIdResponse.respond500WithTextPlain("Internal server error")));
+              logger.error(e.getMessage(), e);
+              asyncResultHandler.handle(Future.succeededFuture(PutPermsPermissionsByIdResponse
+                  .respond500WithTextPlain(getInternalError(e.getMessage()))));
             }
           });
     } catch (Exception e) {
-      logger.error("Error using Postgres instance: " + e.getMessage());
-      asyncResultHandler.handle(Future.succeededFuture(PutPermsPermissionsByIdResponse.respond500WithTextPlain("Internal server error")));
+      logger.error(e.getMessage(), e);
+      asyncResultHandler.handle(Future.succeededFuture(
+          PutPermsPermissionsByIdResponse.respond500WithTextPlain(getInternalError(e.getMessage()))));
     }
   }
 
@@ -1047,7 +1048,7 @@ public class PermsAPI implements Perms {
                       logger.error(errStr, rpfulRes.cause());
                       asyncResultHandler.handle(Future.succeededFuture(
                           DeletePermsPermissionsByIdResponse.respond500WithTextPlain(
-                              getErrorResponse(errStr))));
+                              getInternalError(errStr))));
                     });
                   } else {
                     removeSubpermissionFromPermissionList(connection,
@@ -1059,7 +1060,7 @@ public class PermsAPI implements Perms {
                           logger.error(errStr, rsfplRes.cause());
                           asyncResultHandler.handle(Future.succeededFuture(
                               DeletePermsPermissionsByIdResponse.respond500WithTextPlain(
-                                  getErrorResponse(errStr))));
+                                  getInternalError(errStr))));
                         });
                         return;
                       }
@@ -1072,7 +1073,7 @@ public class PermsAPI implements Perms {
                                 logger.error(errStr, deleteReply.cause());
                                 asyncResultHandler.handle(Future.succeededFuture(
                                     DeletePermsPermissionsByIdResponse.respond500WithTextPlain(
-                                        getErrorResponse(errStr))));
+                                        getInternalError(errStr))));
                               });
                               return;
                             }
@@ -1089,31 +1090,33 @@ public class PermsAPI implements Perms {
               });
             } else {
               try {
-                PostgresClient.getInstance(vertxContext.owner(), tenantId).delete(TABLE_NAME_PERMS, new Criterion(idCrit), deleteReply -> {
-                  if (deleteReply.failed()) {
-                    logger.error("deleteReply failed: " + deleteReply.cause().getMessage());
-                    asyncResultHandler.handle(Future.succeededFuture(
-                        DeletePermsPermissionsByIdResponse.respond500WithTextPlain("Internal server error")));
-                    return;
-                  }
-                  if (deleteReply.result().rowCount() == 0) {
-                    asyncResultHandler.handle(Future.succeededFuture(DeletePermsPermissionsByIdResponse.respond404WithTextPlain(id)));
-                    return;
-                  }
-                  asyncResultHandler.handle(Future.succeededFuture(DeletePermsPermissionsByIdResponse.respond204()));
-                });
+                PostgresClient.getInstance(vertxContext.owner(), tenantId).delete(TABLE_NAME_PERMS,
+                    new Criterion(idCrit), deleteReply -> {
+                      if (deleteReply.failed()) {
+                        logger.error("deleteReply failed: " + deleteReply.cause().getMessage());
+                        asyncResultHandler.handle(Future.succeededFuture(
+                            DeletePermsPermissionsByIdResponse.respond500WithTextPlain(
+                                getInternalError(deleteReply.cause().getMessage()))));
+                        return;
+                      }
+                      if (deleteReply.result().rowCount() == 0) {
+                        asyncResultHandler.handle(Future.succeededFuture(
+                            DeletePermsPermissionsByIdResponse.respond404WithTextPlain(id)));
+                        return;
+                      }
+                      asyncResultHandler.handle(Future.succeededFuture(DeletePermsPermissionsByIdResponse.respond204()));
+                    });
               } catch (Exception e) {
-                logger.error("Error using Postgres instance: " + e.getMessage());
-                asyncResultHandler.handle(Future.succeededFuture(DeletePermsPermissionsByIdResponse.respond500WithTextPlain("Internal server error")));
+                logger.error(e.getMessage(), e);
+                asyncResultHandler.handle(Future.succeededFuture(
+                    DeletePermsPermissionsByIdResponse.respond500WithTextPlain(getInternalError(e.getMessage()))));
               }
             }
           });
     } catch (Exception e) {
-      String errStr = e.getMessage();
-      logger.error(errStr, e);
-      asyncResultHandler.handle(Future.succeededFuture(
-          DeletePermsPermissionsByIdResponse.respond500WithTextPlain(
-              getErrorResponse(errStr))));
+      logger.error(e.getMessage(), e);
+      asyncResultHandler.handle(Future.succeededFuture(DeletePermsPermissionsByIdResponse.respond500WithTextPlain(
+          getInternalError(e.getMessage()))));
     }
   }
 

--- a/src/main/java/org/folio/rest/impl/PermsCache.java
+++ b/src/main/java/org/folio/rest/impl/PermsCache.java
@@ -33,7 +33,7 @@ public class PermsCache {
   public static final String TEST_EXCEPTION_PERMISSION = "a.test.permission.to.trigger.exception";
 
   // 30 seconds cache
-  private static final long CACHE_PERIOD = 30 * 1000L;
+  public static long cachePeriod = 30 * 1000L;
 
   private static final String TAB_PERMS = "permissions";
 
@@ -137,7 +137,7 @@ public class PermsCache {
     }
 
     public boolean isStale() {
-      return System.currentTimeMillis() > (timestamp + CACHE_PERIOD);
+      return System.currentTimeMillis() > (timestamp + cachePeriod);
     }
 
     public boolean hasAll(Set<String> perms) {

--- a/src/main/java/org/folio/rest/impl/PermsCache.java
+++ b/src/main/java/org/folio/rest/impl/PermsCache.java
@@ -32,8 +32,6 @@ public class PermsCache {
 
   public static final String TEST_EXCEPTION_PERMISSION = "a.test.permission.to.trigger.exception";
 
-  // 30 seconds cache
-  public static long cachePeriod = 30 * 1000L;
 
   private static final String TAB_PERMS = "permissions";
 
@@ -43,9 +41,19 @@ public class PermsCache {
   // cache update in progress
   private static final ConcurrentMap<String, Long> CACHE_WIP = new ConcurrentHashMap<>();
 
+  // 30 seconds cache
+  private static long cachePeriod = 30 * 1000L;
+
   private PermsCache() {
   }
 
+  /**
+   * set cache period in millisecond.
+   * @param ms in milliseconds
+   */
+  public static void setCachePeriod(long ms) {
+    cachePeriod = ms;
+  }
   /**
    * Expand permission list to include all sub permissions recursively.
    *

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -379,7 +379,7 @@ public class RestVerticleTest {
     send(url, context, HttpMethod.GET, "",
         SUPPORTED_CONTENT_TYPE_JSON_DEF,  new HTTPResponseHandler(futureResponse));
     Response addPermsResponse = futureResponse.get(5, TimeUnit.SECONDS);
-    context.assertEquals(200, addPermsResponse.code);
+    context.assertEquals(400, addPermsResponse.code);
   }
 
   @Test

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -6,7 +6,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
@@ -33,7 +32,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 import org.folio.permstest.TestUtil.WrappedResponse;
-import org.folio.rest.impl.PermsAPI;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.RestVerticle;
@@ -81,6 +79,7 @@ public class RestVerticleTest {
 
 
   private static Vertx vertx;
+  private static HttpClient client;
   static int port;
 
   @Rule
@@ -90,8 +89,9 @@ public class RestVerticleTest {
   public static void setup(TestContext context) {
     Async async = context.async();
     port = NetworkUtils.nextFreePort();
-    TenantClient tenantClient = new TenantClient("http://localhost:" + port, "diku", "diku");
+    TenantClient tenantClient = new TenantClient("http://localhost:" + port, "diku",  null);
     vertx = Vertx.vertx();
+    client = vertx.createHttpClient();
     DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject()
         .put("http.port", port).put(PermsCache.CACHE_HEADER, false)).setWorker(true);
     try {
@@ -122,6 +122,7 @@ public class RestVerticleTest {
   @AfterClass
   public static void teardown(TestContext context) {
     Async async = context.async();
+    client.close();
     vertx.close(context.asyncAssertSuccess( res-> {
       PostgresClient.stopEmbeddedPostgres();
       async.complete();
@@ -196,7 +197,31 @@ public class RestVerticleTest {
   }
 
   @Test
-  public void testPermsUsersPermissionsInvalidUUID(TestContext context)
+  public void testGetPermsUsersByIdBadIndexField(TestContext context)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/users/123?indexField=bad";
+
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send(url, context, HttpMethod.GET, null,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF,  new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(500, response.code);
+  }
+
+  @Test
+  public void testGetPermsUsersByIdBadUUID(TestContext context)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/users/1234?indexField=id";
+
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send(url, context, HttpMethod.GET, null,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF,  new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(404, response.code);
+  }
+
+  @Test
+  public void testPostPermsUsersPermissionsInvalidUUID(TestContext context)
       throws InterruptedException, ExecutionException, TimeoutException {
     String url = "http://localhost:" + port + "/perms/users/123/permissions";
 
@@ -208,7 +233,54 @@ public class RestVerticleTest {
   }
 
   @Test
-  public void testPermsUsersPutInvalidUUID(TestContext context)
+  public void testPostPermsUsersInvalidUUID(TestContext context)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/users";
+
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+
+    String permsUsers = "{\"userId\": \"1234\",\"permissions\": " +
+        "[], \"id\" : \"1234\"}";
+
+    send(url, context, HttpMethod.POST, permsUsers,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF,  new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(400, response.code);
+  }
+
+  @Test
+  public void testPostPermsUsersNoUserId(TestContext context)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/users";
+
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+
+    String permsUsers = "{\"permissions\": [], \"id\" : \"1234\"}";
+
+    send(url, context, HttpMethod.POST, permsUsers,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF,  new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(400, response.code);
+  }
+
+  @Test
+  public void testPostPermsUsersBadTenant(TestContext context)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/users";
+
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+
+    String permsUsersWithBadUUID = "{\"userId\": \""+ userUserId +"\",\"permissions\": " +
+        "[], \"id\" : \"1234\"}";
+
+    send("badTenant", url, context, HttpMethod.POST, permsUsersWithBadUUID,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF,  new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(400, response.code);
+  }
+
+  @Test
+  public void testPutPermsUsersInvalidUUID(TestContext context)
       throws InterruptedException, ExecutionException, TimeoutException {
     String url = "http://localhost:" + port + "/perms/users/123";
 
@@ -220,7 +292,7 @@ public class RestVerticleTest {
   }
 
   @Test
-  public void testPermsUsersDeleteInvalidUUID(TestContext context)
+  public void testDeletePermsUsersInvalidUUID(TestContext context)
       throws InterruptedException, ExecutionException, TimeoutException {
     String url = "http://localhost:" + port + "/perms/users/123";
 
@@ -230,6 +302,37 @@ public class RestVerticleTest {
     Response response = futureResponse.get(5, TimeUnit.SECONDS);
     context.assertEquals(404, response.code);
   }
+
+  @Test
+  public void testPutPermsUsersByIdNonExistingPerm(TestContext context)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/users/123";
+
+    String permsUsers = "{\"userId\": \"1234\",\"permissions\": " +
+        "[\"foo\"], \"id\" : \"1234\"}";
+
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send(url, context, HttpMethod.PUT, permsUsers,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF,  new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(404, response.code);
+  }
+
+  @Test
+  public void testPutPermsUsersByIdBadTenant(TestContext context)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/users/123";
+
+    String permsUsers = "{\"userId\": \"1234\",\"permissions\": " +
+        "[\"foo\"], \"id\" : \"1234\"}";
+
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send("badTenant", url, context, HttpMethod.PUT, permsUsers,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF,  new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(400, response.code);
+  }
+
 
   @Test
   public void testPermsUsersGetCqlError(TestContext context)
@@ -268,6 +371,27 @@ public class RestVerticleTest {
   }
 
   @Test
+  public void testPostPermsPermissions(TestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/permissions";
+
+    String uuid = UUID.randomUUID().toString();
+    String postPermRequest = "{\"id\": \"" + uuid + "\", \"permissionName\":\"aaname\",\"displayName\":\"aadisplay\"}";
+
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send(url, context, HttpMethod.POST, postPermRequest,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(response.code, 201);
+    context.assertEquals(uuid, response.body.getString("id")); // MODPERMS-84
+
+    futureResponse = new CompletableFuture();
+    send(url + "/" + uuid, context, HttpMethod.DELETE, null,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
+    response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(response.code, 204);
+  }
+
+  @Test
   public void testGroup(TestContext context) throws InterruptedException, ExecutionException, TimeoutException {
     String url = "http://localhost:"+port+"/perms/users";
 
@@ -283,6 +407,7 @@ public class RestVerticleTest {
         SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
     response = futureResponse.get(5, TimeUnit.SECONDS);
     context.assertEquals(response.code, HttpURLConnection.HTTP_CREATED);
+    String permUuid = response.body.getString("id");
 
     /* get it back */
     futureResponse = new CompletableFuture();
@@ -307,7 +432,6 @@ public class RestVerticleTest {
     context.assertEquals(response.code, 422);
 
     /* add a perm user with a non-existent perm */
-
     futureResponse = new CompletableFuture();
     send(url, context, HttpMethod.POST, postBadPermUsersRequest,
         SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
@@ -359,6 +483,12 @@ public class RestVerticleTest {
     logger.debug(response.body +
         "\nStatus - " + response.code + " at " + System.currentTimeMillis() + " for "
         + addPermURL);
+
+    futureResponse = new CompletableFuture();
+    send(permUrl + "/" + permUuid, context, HttpMethod.DELETE, null,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
+    response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(response.code, 204);
 
     /* Try to add a new permission with a non-existent sub */
     JsonObject addNewBadPermRequestObject = new JsonObject()
@@ -692,38 +822,26 @@ public class RestVerticleTest {
         new HTTPResponseHandler(futureResponse));
     response = futureResponse.get(5, TimeUnit.SECONDS);
     context.assertEquals(response.code, 404);
+
   }
 
   private void send(String url, TestContext context, HttpMethod method, String content,
                     String contentType, Handler<HttpClientResponse> handler) {
-    HttpClient client = vertx.createHttpClient();
-    HttpClientRequest request;
-    if(content == null){
-      content = "";
-    }
-    Buffer buffer = Buffer.buffer(content);
+    send("diku", url, context, method, content, contentType, handler);
+  }
 
-    if (method == HttpMethod.POST) {
-      request = client.postAbs(url);
-    }
-    else if (method == HttpMethod.DELETE) {
-      request = client.deleteAbs(url);
-    }
-    else if (method == HttpMethod.GET) {
-      request = client.getAbs(url);
-    }
-    else {
-      request = client.putAbs(url);
-    }
-    request.exceptionHandler(error -> {
-      context.fail(error.getMessage());
-    })
-        .handler(handler);
-    request.putHeader("Authorization", "diku");
-    request.putHeader("x-okapi-tenant", "diku");
+  private void send(String tenant, String url, TestContext context, HttpMethod method, String content,
+                    String contentType, Handler<HttpClientResponse> handler) {
+    HttpClientRequest request = client.requestAbs(method, url);
+    request.exceptionHandler(error -> context.fail(error.getMessage())).handler(handler);
+    request.putHeader("x-okapi-tenant", tenant);
     request.putHeader("Accept", "application/json,text/plain");
     request.putHeader("Content-type", contentType);
-    request.end(buffer);
+    if (content == null) {
+      request.end();
+    } else {
+      request.end(content);
+    }
     logger.debug("Sending " + method.toString() + " request to " +
         url + " with content '" + content + "'");
   }

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -501,6 +501,16 @@ public class RestVerticleTest {
   }
 
   @Test
+  public void testGetPermsPermissionsByIdBadTenant(TestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/permissions/123";
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send("badTenant", url, context, HttpMethod.GET, null,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(response.code, 400);
+  }
+
+  @Test
   public void testGroup(TestContext context) throws InterruptedException, ExecutionException, TimeoutException {
     String url = "http://localhost:"+port+"/perms/users";
 

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -221,6 +221,18 @@ public class RestVerticleTest {
   }
 
   @Test
+  public void testGetPermsUsersByBadTenant(TestContext context)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/users/1234?indexField=id";
+
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send("badTenant", url, context, HttpMethod.GET, null,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF,  new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(400, response.code);
+  }
+
+  @Test
   public void testPostPermsUsersPermissionsInvalidUUID(TestContext context)
       throws InterruptedException, ExecutionException, TimeoutException {
     String url = "http://localhost:" + port + "/perms/users/123/permissions";

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -221,12 +221,24 @@ public class RestVerticleTest {
   }
 
   @Test
-  public void testGetPermsUsersByBadTenant(TestContext context)
+  public void testGetPermsUsersByIdBadTenant(TestContext context)
       throws InterruptedException, ExecutionException, TimeoutException {
-    String url = "http://localhost:" + port + "/perms/users/1234?indexField=id";
+    String url = "http://localhost:" + port + "/perms/users/1234";
 
     CompletableFuture<Response> futureResponse = new CompletableFuture();
     send("badTenant", url, context, HttpMethod.GET, null,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF,  new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(400, response.code);
+  }
+
+  @Test
+  public void testDeletePermsUsersByIdBadTenant(TestContext context)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/users/1234";
+
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send("badTenant", url, context, HttpMethod.DELETE, null,
         SUPPORTED_CONTENT_TYPE_JSON_DEF,  new HTTPResponseHandler(futureResponse));
     Response response = futureResponse.get(5, TimeUnit.SECONDS);
     context.assertEquals(400, response.code);
@@ -383,14 +395,99 @@ public class RestVerticleTest {
   }
 
   @Test
+  public void testPostPermsPermissionsBadTenant(TestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/permissions";
+    String permRequest = "{\"permissionName\":\"aaname\",\"displayName\":\"aadisplay\"}";
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send("badTenant", url, context, HttpMethod.POST, permRequest,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(response.code, 400);
+  }
+
+  @Test
+  public void testPostPermsUsersPermissionsByIdBadTenant(TestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/users/123/permissions";
+    String permRequest = "{\"permissionName\":\"aaname\",\"displayName\":\"aadisplay\"}";
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send("badTenant", url, context, HttpMethod.POST, permRequest,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(response.code, 400);
+  }
+
+  @Test
+  public void testGetPermsUsersPermissionsByIdBadTenant(TestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/users/123/permissions";
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send("badTenant", url, context, HttpMethod.GET, null,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(response.code, 400);
+  }
+
+  @Test
+  public void testPutPermsPermissionsByIdBadIdValue(TestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/permissions/123";
+    String permRequest = "{\"permissionName\":\"aaname\",\"displayName\":\"aadisplay\"}";
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send(url, context, HttpMethod.PUT, permRequest,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(response.code, 400);
+  }
+
+  @Test
+  public void testPutPermsPermissionsByIdNotFound(TestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/permissions/123";
+    String permRequest = "{\"id\": \"123\", \"permissionName\":\"aaname\",\"displayName\":\"aadisplay\"}";
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send(url, context, HttpMethod.PUT, permRequest,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(response.code, 404);
+  }
+
+  @Test
+  public void testPutPermsPermissionsByIdBadTenant(TestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/permissions/123";
+    String permRequest = "{\"id\": \"123\", \"permissionName\":\"aaname\",\"displayName\":\"aadisplay\"}";
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send("badTenant", url, context, HttpMethod.PUT, permRequest,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(response.code, 400);
+  }
+
+  @Test
+  public void testDeletePermsPermissionsByIdBadTenant(TestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/permissions/123";
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send("badTenant", url, context, HttpMethod.DELETE, null,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(response.code, 400);
+  }
+
+  @Test
+  public void testDeletePermsUsersPermissionsByIdAndPermissionnameBadTenant(TestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    String url = "http://localhost:" + port + "/perms/users/123/permissions/name";
+    CompletableFuture<Response> futureResponse = new CompletableFuture();
+    send("badTenant", url, context, HttpMethod.DELETE, null,
+        SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
+    Response response = futureResponse.get(5, TimeUnit.SECONDS);
+    context.assertEquals(response.code, 400);
+  }
+
+  @Test
   public void testPostPermsPermissions(TestContext context) throws InterruptedException, ExecutionException, TimeoutException {
     String url = "http://localhost:" + port + "/perms/permissions";
 
     String uuid = UUID.randomUUID().toString();
-    String postPermRequest = "{\"id\": \"" + uuid + "\", \"permissionName\":\"aaname\",\"displayName\":\"aadisplay\"}";
+    String permRequest = "{\"id\": \"" + uuid + "\", \"permissionName\":\"aaname\",\"displayName\":\"aadisplay\"}";
 
     CompletableFuture<Response> futureResponse = new CompletableFuture();
-    send(url, context, HttpMethod.POST, postPermRequest,
+    send(url, context, HttpMethod.POST, permRequest,
         SUPPORTED_CONTENT_TYPE_JSON_DEF, new HTTPResponseHandler(futureResponse));
     Response response = futureResponse.get(5, TimeUnit.SECONDS);
     context.assertEquals(response.code, 201);

--- a/src/test/java/org/folio/permstest/RestVerticleWithCacheTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleWithCacheTest.java
@@ -53,7 +53,7 @@ public class RestVerticleWithCacheTest {
   public static void setup(TestContext context) {
     Async async = context.async();
     port = NetworkUtils.nextFreePort();
-    PermsCache.cachePeriod = 3000;
+    PermsCache.setCachePeriod(3000);
     TenantClient tenantClient = new TenantClient("http://localhost:" + port, "diku", null);
     vertx = Vertx.vertx();
     DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("http.port", port))

--- a/src/test/java/org/folio/permstest/RestVerticleWithCacheTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleWithCacheTest.java
@@ -54,7 +54,7 @@ public class RestVerticleWithCacheTest {
     Async async = context.async();
     port = NetworkUtils.nextFreePort();
     PermsCache.cachePeriod = 3000;
-    TenantClient tenantClient = new TenantClient("http://localhost:" + port, "diku", "diku");
+    TenantClient tenantClient = new TenantClient("http://localhost:" + port, "diku", null);
     vertx = Vertx.vertx();
     DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("http.port", port))
         .setWorker(true);

--- a/src/test/java/org/folio/permstest/RestVerticleWithCacheTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleWithCacheTest.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import org.folio.permstest.TestUtil.WrappedResponse;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
+import org.folio.rest.impl.PermsCache;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.rest.jaxrs.model.Parameter;
@@ -52,6 +53,7 @@ public class RestVerticleWithCacheTest {
   public static void setup(TestContext context) {
     Async async = context.async();
     port = NetworkUtils.nextFreePort();
+    PermsCache.cachePeriod = 3000;
     TenantClient tenantClient = new TenantClient("http://localhost:" + port, "diku", "diku");
     vertx = Vertx.vertx();
     DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("http.port", port))
@@ -106,7 +108,7 @@ public class RestVerticleWithCacheTest {
       return testUserPerms(context, w.getJson().getString("id"));
     }).compose(w -> {
       // refresh cache
-      return testSubPermExpansionAfterWait(context, Arrays.asList(P_READ, P_WRITE), 32);
+      return testSubPermExpansionAfterWait(context, Arrays.asList(P_READ, P_WRITE), 4);
     }).compose(w -> {
       // test again
       return testSubPermExpansionAfterWait(context, Arrays.asList(P_READ, P_WRITE, P_DELETE), 2);


### PR DESCRIPTION
Fixes the issue of MODPERMS-84. It also returns 400 error where it previously returned 500 in a number of cases where user input . eg tenant is bad and fails due to bad user input. Not an internal error.. The 500 error handling has been re-done.. and so the coverage is low for this PR. Still overall coverage is up from 63.7 to 71.1.