### PR TITLE
MODPERMS-96: Update to raml-module-builder (RMB) 30.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,13 +32,13 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>30.2.5</version>
+      <version>30.2.6</version>
     </dependency>
 
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>3.9.1</version>
+      <version>3.9.2</version>
       <scope>test</scope>
       <type>jar</type>
     </dependency>


### PR DESCRIPTION
RMB 30.2.6 release notes: https://github.com/folio-org/raml-module-builder/releases/tag/v30.2.6

 * [RMB-701](https://issues.folio.org/browse/RMB-701) Update to [Vert.x 3.9.2](https://github.com/vert-x3/wiki/wiki/3.9.2-Release-Notes), fixing WebClient request timeout races
 * [RMB-700](https://issues.folio.org/browse/RMB-700) NPE when RestVerticle calls LogUtil.formatStatsLogMessage
 * [RMB-677](https://issues.folio.org/browse/RMB-677) Close PostgreSQL connection after invalid CQL failure