### PR TITLE
MODPERMS-97: Release 5.11.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
+## 2020-08-28 v5.11.3
+
+ * [MODPERMS-96](https://issues.folio.org/browse/MODPERMS-96) Update to raml-module-builder (RMB) 30.2.6
+ * [MODPERMS-95](https://issues.folio.org/browse/MODPERMS-95) Upgrade to raml-module-builder (RMB) 30.2.5
+
 ## 2020-07-14 v5.11.2
 
- * [MODPERMS-88](https://issues.folio.org/browse/MODPERMS-88) Upgrade issue between Q1 and Q2: "public.gin_trgm_ops" does not exist
+ * [MODPERMS-88](https://issues.folio.org/browse/MODPERMS-88) Upgrade issue between Q1 and Q2: "public.gin\_trgm\_ops" does not exist
 
 ## 2020-06-24 v5.11.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-permissions</artifactId>
-  <version>5.11.3-SNAPSHOT</version>
+  <version>5.11.3</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -340,7 +340,7 @@
     <url>https://github.com/folio-org/mod-permissions</url>
     <connection>scm:git:git://github.com:folio-org/mod-permissions.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-permissions.git</developerConnection>
-    <tag>v5.11.0</tag>
+    <tag>v5.11.3</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>30.2.4</version>
+      <version>30.2.5</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-permissions</artifactId>
-  <version>5.11.3</version>
+  <version>5.11.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -340,7 +340,7 @@
     <url>https://github.com/folio-org/mod-permissions</url>
     <connection>scm:git:git://github.com:folio-org/mod-permissions.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-permissions.git</developerConnection>
-    <tag>v5.11.3</tag>
+    <tag>v5.11.0</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -32,13 +32,13 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>30.2.5</version>
+      <version>30.2.6</version>
     </dependency>
 
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>3.9.1</version>
+      <version>3.9.2</version>
       <scope>test</scope>
       <type>jar</type>
     </dependency>


### PR DESCRIPTION
Upgrade to raml-module-builder (RMB) from 30.2.4 to 30.2.6.