### PR TITLE
MODPERMS-99: Don't return metadata on PUT /perms/users/<id>

### DIFF
--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -356,6 +356,9 @@ public class PermsAPI implements Perms {
                   }
                   //close Tx
                   pgClient.endTx(connection, done -> {
+                    // https://issues.folio.org/browse/MODPERMS-99
+                    // Remove inconsistent metadata - the update trigger uses different data
+                    entity.setMetadata(null);
                     asyncResultHandler.handle(Future.succeededFuture(
                         PutPermsUsersByIdResponse.respond200WithApplicationJson(entity)));
                   });


### PR DESCRIPTION
RMB provides PgUtil.put that returns 204 "No content" on success, and no body/no entity:
https://github.com/folio-org/raml-module-builder/blob/v31.1.0/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java#L931-L949

mod-permissions PUT /perms/users/{id} neither uses PgUtil.put nor 204. It uses 200 instead an therefore need to create the correct reply on its own.

This should be changed to the usual 204 response that most other FOLIO PUT APIs use.

To fix the inconsistency I remove the metadata property as suggested in this issues's description.