### PR TITLE
Allow re-use of deprecated permissions MODPERMS-130

### DIFF
--- a/src/main/java/org/folio/rest/impl/TenantPermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantPermsAPI.java
@@ -106,8 +106,8 @@ perm.setModuleName(moduleId.getProduct());
                     if (dbPerm == null || Boolean.TRUE.equals(dbPerm.getDummy())) {
                       return Future.succeededFuture();
                     }
-                    if (dbPerm != null && Boolean.FALSE.equals(dbPerm.getMutable())
-                        && PermissionUtils.equals(perm, dbPerm)) {
+                    if (Boolean.TRUE.equals(dbPerm.getDeprecated()) || (Boolean.FALSE.equals(dbPerm.getMutable())
+                        && PermissionUtils.equals(perm, dbPerm))) {
                       // (B) we have a match, but lack moduleName. Fix it before we add it.
                       return addMissingModuleContext(dbPerm, moduleId, vertxContext, tenantId)
                           .onFailure(Future::failedFuture)

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -328,6 +328,41 @@ public class RestVerticleTest {
     context.assertEquals(201, response.code);
   }
 
+  // Test that a permission can be used in another module if first one is deleted MODPERMS-130
+  @Test
+  public void testPermissionsOnTheMove(TestContext context) {
+    String perm = "perm" + UUID.randomUUID().toString();
+    JsonObject permissionSet = new JsonObject()
+        .put("moduleId","moduleA")
+        .put("perms", new JsonArray()
+            .add(new JsonObject()
+                .put("permissionName", perm)
+                .put("displayName", "Description A")
+                )
+            );
+    Response response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    context.assertEquals(201, response.code);
+
+    // remove permissions for moduleA
+    permissionSet = new JsonObject()
+        .put("moduleId","moduleA")
+        .put("perms", new JsonArray());
+    response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    context.assertEquals(201, response.code);
+
+    // use same permission again in other module with new definition
+    permissionSet = new JsonObject()
+        .put("moduleId","moduleB")
+        .put("perms", new JsonArray()
+            .add(new JsonObject()
+                .put("permissionName", perm)
+                .put("displayName", "Description B")
+            )
+        );
+    response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    context.assertEquals(201, response.code);
+  }
+
   @Test
   public void testPutPermsUsersByIdDummyPerm(TestContext context) {
     String postPermUsersRequest = "{\"userId\": \""+ userUserId +"\",\"permissions\": " +


### PR DESCRIPTION
This PR fixes the problems as described in MODPERMS-130.

It also fixes a problem where permission could get a new module context if the structure was the same. That means multiple modules could be enabled and definitions could start to differ for same permission.