### PR TITLE
Allow reuse of permissions MODPERMS-130

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_size = 2
+continuation_indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/src/main/java/org/folio/rest/impl/TenantPermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantPermsAPI.java
@@ -106,8 +106,8 @@ perm.setModuleName(moduleId.getProduct());
                     if (dbPerm == null || Boolean.TRUE.equals(dbPerm.getDummy())) {
                       return Future.succeededFuture();
                     }
-                    if (dbPerm != null && Boolean.FALSE.equals(dbPerm.getMutable())
-                        && PermissionUtils.equals(perm, dbPerm)) {
+                    if (Boolean.TRUE.equals(dbPerm.getDeprecated()) || (Boolean.FALSE.equals(dbPerm.getMutable())
+                        && PermissionUtils.equals(perm, dbPerm))) {
                       // (B) we have a match, but lack moduleName. Fix it before we add it.
                       return addMissingModuleContext(dbPerm, moduleId, vertxContext, tenantId)
                           .onFailure(Future::failedFuture)

--- a/src/main/java/org/folio/rest/impl/TenantPermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantPermsAPI.java
@@ -107,6 +107,11 @@ perm.setModuleName(moduleId.getProduct());
                         // permission does not already exist or is dummy
                         return Future.succeededFuture();
                       }
+                      // we only allow overwrite for immutable permissions (those posted with tenantPermissions)
+                      // and if one of the following it true:
+                      // 1: it's deprecated
+                      // 2: no module context (yet)
+                      // 3: same module context
                       if (Boolean.FALSE.equals(dbPerm.getMutable()) &&
                           (Boolean.TRUE.equals(dbPerm.getDeprecated())
                               || dbPerm.getModuleName() == null

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -328,6 +328,41 @@ public class RestVerticleTest {
     context.assertEquals(201, response.code);
   }
 
+  // Test that a permission can be used in another module if first one is deleted MODPERMS-130
+  @Test
+  public void testPermissionsOnTheMove(TestContext context) {
+    String perm = "perm" + UUID.randomUUID().toString();
+    JsonObject permissionSet = new JsonObject()
+        .put("moduleId","moduleA")
+        .put("perms", new JsonArray()
+            .add(new JsonObject()
+                .put("permissionName", perm)
+                .put("displayName", "Description A")
+                )
+            );
+    Response response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    context.assertEquals(201, response.code);
+
+    // remove permissions for moduleA
+    permissionSet = new JsonObject()
+        .put("moduleId","moduleA")
+        .put("perms", new JsonArray());
+    response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    context.assertEquals(201, response.code);
+
+    // use same permission again in other module with new definition
+    permissionSet = new JsonObject()
+        .put("moduleId","moduleB")
+        .put("perms", new JsonArray()
+            .add(new JsonObject()
+                .put("permissionName", perm)
+                .put("displayName", "Description B")
+            )
+        );
+    response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    context.assertEquals(201, response.code);
+  }
+
   @Test
   public void testPutPermsUsersByIdDummyPerm(TestContext context) {
     String postPermUsersRequest = "{\"userId\": \""+ userUserId +"\",\"permissions\": " +

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -391,6 +391,61 @@ public class RestVerticleTest {
   }
 
   @Test
+  public void testSameModuleCanChangeDefinition(TestContext context) {
+    String perm = "perm" + UUID.randomUUID().toString();
+    JsonObject permissionSet = new JsonObject()
+        .put("moduleId","moduleA2-1.0.0")
+        .put("perms", new JsonArray()
+            .add(new JsonObject()
+                .put("permissionName", perm)
+                .put("displayName", "Description 1")
+            )
+        );
+    Response response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    context.assertEquals(201, response.code);
+
+    // use same permission in other module with same definition
+    permissionSet = new JsonObject()
+        .put("moduleId","moduleA2-1.0.1")
+        .put("perms", new JsonArray()
+            .add(new JsonObject()
+                .put("permissionName", perm)
+                .put("displayName", "Description 2")
+            )
+        );
+    response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    context.assertEquals(201, response.code);
+  }
+
+  @Test
+  public void testOtherModuleCanNotChangeDefinition(TestContext context) {
+    String perm = "perm" + UUID.randomUUID().toString();
+    JsonObject permissionSet = new JsonObject()
+        .put("moduleId","moduleA3-1.0.0")
+        .put("perms", new JsonArray()
+            .add(new JsonObject()
+                .put("permissionName", perm)
+                .put("displayName", "Description 1")
+            )
+        );
+    Response response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    context.assertEquals(201, response.code);
+
+    // use same permission in other module with same definition
+    permissionSet = new JsonObject()
+        .put("moduleId","moduleB3-1.0.0")
+        .put("perms", new JsonArray()
+            .add(new JsonObject()
+                .put("permissionName", perm)
+                .put("displayName", "Description 1")
+            )
+        );
+    response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    context.assertEquals(400, response.code);
+  }
+
+
+  @Test
   public void testPutPermsUsersByIdDummyPerm(TestContext context) {
     String postPermUsersRequest = "{\"userId\": \""+ userUserId +"\",\"permissions\": " +
         "[], \"id\" : \"" + userId2 + "\"}";

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -329,6 +329,10 @@ public class RestVerticleTest {
   }
 
   // Test that a permission can be used in another module if first one is deleted MODPERMS-130
+  // This may happen if a module is deprecated and simply renamed, but keep providing the same interfaces
+  // and permissions
+  // Or there really are two modules out there offering the same interface and permissions (and only
+  // one can be enabled at a time).
   @Test
   public void testPermissionsOnTheMove(TestContext context) {
     String perm = "perm" + UUID.randomUUID().toString();
@@ -343,7 +347,7 @@ public class RestVerticleTest {
     Response response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
     context.assertEquals(201, response.code);
 
-    // remove permissions for moduleA
+    // remove permissions for it / OKAPI-982
     permissionSet = new JsonObject()
         .put("moduleId","moduleA0")
         .put("perms", new JsonArray());
@@ -387,6 +391,7 @@ public class RestVerticleTest {
             )
         );
     response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    // fails because we can only have one module offering a permission
     context.assertEquals(400, response.code);
   }
 
@@ -404,7 +409,7 @@ public class RestVerticleTest {
     Response response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
     context.assertEquals(201, response.code);
 
-    // use same permission in other module with same definition
+    // update the module with an updated permission definition
     permissionSet = new JsonObject()
         .put("moduleId","moduleA2-1.0.1")
         .put("perms", new JsonArray()

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -333,7 +333,7 @@ public class RestVerticleTest {
   public void testPermissionsOnTheMove(TestContext context) {
     String perm = "perm" + UUID.randomUUID().toString();
     JsonObject permissionSet = new JsonObject()
-        .put("moduleId","moduleA")
+        .put("moduleId","moduleA0")
         .put("perms", new JsonArray()
             .add(new JsonObject()
                 .put("permissionName", perm)
@@ -345,14 +345,14 @@ public class RestVerticleTest {
 
     // remove permissions for moduleA
     permissionSet = new JsonObject()
-        .put("moduleId","moduleA")
+        .put("moduleId","moduleA0")
         .put("perms", new JsonArray());
     response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
     context.assertEquals(201, response.code);
 
     // use same permission again in other module with new definition
     permissionSet = new JsonObject()
-        .put("moduleId","moduleB")
+        .put("moduleId","moduleB0")
         .put("perms", new JsonArray()
             .add(new JsonObject()
                 .put("permissionName", perm)
@@ -367,7 +367,7 @@ public class RestVerticleTest {
   public void testPermissionsChangingInMultipleModules(TestContext context) {
     String perm = "perm" + UUID.randomUUID().toString();
     JsonObject permissionSet = new JsonObject()
-        .put("moduleId","moduleA-1.0.0")
+        .put("moduleId","moduleA1-1.0.0")
         .put("perms", new JsonArray()
             .add(new JsonObject()
                 .put("permissionName", perm)
@@ -379,31 +379,7 @@ public class RestVerticleTest {
 
     // use same permission in other module with same definition
     permissionSet = new JsonObject()
-        .put("moduleId","moduleB-1.0.0")
-        .put("perms", new JsonArray()
-            .add(new JsonObject()
-                .put("permissionName", perm)
-                .put("displayName", "Description 1")
-            )
-        );
-    response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
-    context.assertEquals(201, response.code);
-
-    // lets change the definition in other module
-    permissionSet = new JsonObject()
-        .put("moduleId","moduleB-1.0.1")
-        .put("perms", new JsonArray()
-            .add(new JsonObject()
-                .put("permissionName", perm)
-                .put("displayName", "Description 2")
-            )
-        );
-    response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
-    context.assertEquals(201, response.code);
-
-    // module A upgraded with its ORIGINAL definition gives collision!
-    permissionSet = new JsonObject()
-        .put("moduleId","moduleA-1.0.1")
+        .put("moduleId","moduleB1-1.0.0")
         .put("perms", new JsonArray()
             .add(new JsonObject()
                 .put("permissionName", perm)


### PR DESCRIPTION
This PR fixes the problems as described in MODPERMS-130.

It also fixes a problem where permission could get a new module context if the structure was the same. That means multiple modules could be enabled and definitions could start to differ for same permission.