### PR TITLE
Do not assign context to dummy permissions MODPERMS-133

### DIFF
--- a/src/main/java/org/folio/rest/impl/TenantPermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantPermsAPI.java
@@ -721,7 +721,8 @@ perm.setModuleName(moduleId.getProduct());
               if ((perm.getSubPermissions() != null && !perm.getSubPermissions().equals(foundPerm.getSubPermissions()))
                   || (perm.getVisible() != null && !perm.getVisible().equals(foundPerm.getVisible()))
                   || (perm.getDisplayName() != null && !perm.getDisplayName().equals(foundPerm.getDisplayName()))
-                  || (perm.getDescription() != null && !perm.getDescription().equals(foundPerm.getDescription()))) {
+                  || (perm.getDescription() != null && !perm.getDescription().equals(foundPerm.getDescription()))
+                  || (moduleId.getSemVer() != null && !moduleId.getSemVer().toString().equals(foundPerm.getModuleVersion()))) {
                 foundPerm.setDummy(true);
               }
             }

--- a/src/main/java/org/folio/rest/impl/TenantPermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantPermsAPI.java
@@ -712,7 +712,7 @@ perm.setModuleName(moduleId.getProduct());
             Permission foundPerm = null;
             if (!returnList.isEmpty()) {
               foundPerm = returnList.get(0);
-              if (foundPerm.getModuleName() == null) {
+              if (!Boolean.FALSE.equals(foundPerm.getMutable())) {
                 pgClient.rollbackTx(connection, rollback ->
                   promise.fail("PermissionName collision with user-defined permission: " + perm.getPermissionName()));
                 return;
@@ -721,8 +721,7 @@ perm.setModuleName(moduleId.getProduct());
               if ((perm.getSubPermissions() != null && !perm.getSubPermissions().equals(foundPerm.getSubPermissions()))
                   || (perm.getVisible() != null && !perm.getVisible().equals(foundPerm.getVisible()))
                   || (perm.getDisplayName() != null && !perm.getDisplayName().equals(foundPerm.getDisplayName()))
-                  || (perm.getDescription() != null && !perm.getDescription().equals(foundPerm.getDescription()))
-                  || (moduleId.getSemVer() != null && !moduleId.getSemVer().toString().equals(foundPerm.getModuleVersion()))) {
+                  || (perm.getDescription() != null && !perm.getDescription().equals(foundPerm.getDescription()))) {
                 foundPerm.setDummy(true);
               }
             }
@@ -869,7 +868,7 @@ perm.setModuleName(moduleId.getProduct());
             //permission already exists
             promise.complete();
           } else {
-            makeDummyPerm(connection, perm, moduleId, vertxContext, tenantId).onComplete(
+            makeDummyPerm(connection, perm, vertxContext, tenantId).onComplete(
                 makeDummyRes -> promise.handle(makeDummyRes.mapEmpty()));
           }
         }
@@ -879,7 +878,7 @@ perm.setModuleName(moduleId.getProduct());
   }
 
   private Future<Void> makeDummyPerm(AsyncResult<SQLConnection> connection, String perm,
-      ModuleId moduleId, Context vertxContext, String tenantId) {
+      Context vertxContext, String tenantId) {
 
     Promise<Void> promise = Promise.promise();
     Permission dummyPermission = new Permission();
@@ -889,9 +888,6 @@ perm.setModuleName(moduleId.getProduct());
     dummyPermission.setDummy(true);
     dummyPermission.setVisible(false);
     dummyPermission.setMutable(false);
-    dummyPermission.setModuleName(moduleId.getProduct());
-    SemVer semver = moduleId.getSemVer();
-    dummyPermission.setModuleVersion(semver != null ? semver.toString() : null);
 
     PostgresClient pgClient = PostgresClient.getInstance(vertxContext.owner(), tenantId);
     pgClient.save(connection, TABLE_NAME_PERMS, newId, dummyPermission,

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -449,6 +449,72 @@ public class RestVerticleTest {
     context.assertEquals(400, response.code);
   }
 
+  @Test
+  public void testDummyPerm(TestContext context) {
+    String perm1 = "permA" + UUID.randomUUID().toString();
+    String perm2 = "permB" + UUID.randomUUID().toString();
+    String dummy = "dummy" + UUID.randomUUID().toString();
+    JsonObject permissionSet = new JsonObject()
+        .put("moduleId","moduleA4-1.0.0")
+        .put("perms", new JsonArray()
+            .add(new JsonObject()
+                .put("permissionName", perm1)
+                .put("displayName", "Description 1")
+                .put("subPermissions", new JsonArray()
+                    .add(dummy))
+            )
+        );
+    Response response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    context.assertEquals(201, response.code);
+
+    response = send(HttpMethod.GET, "/perms/permissions?includeDummy=true&query=permissionName%3D" + dummy, null, context);
+    context.assertEquals(200, response.code);
+    JsonObject permObject = response.body.getJsonArray("permissions").getJsonObject(0);
+    context.assertEquals(dummy, permObject.getString("permissionName"));
+    context.assertFalse(permObject.containsKey("moduleName"));
+    context.assertFalse(permObject.containsKey("moduleVersion"));
+    context.assertTrue(permObject.getBoolean("dummy"), permObject.encode());
+
+    response = send(HttpMethod.GET, "/perms/permissions?includeDummy=true&query=permissionName%3D" + perm1, null, context);
+    context.assertEquals(200, response.code);
+    permObject = response.body.getJsonArray("permissions").getJsonObject(0);
+    context.assertEquals(perm1, permObject.getString("permissionName"));
+    context.assertEquals("moduleA4", permObject.getString("moduleName"));
+    context.assertEquals("1.0.0", permObject.getString("moduleVersion"));
+    context.assertFalse(permObject.getBoolean("dummy"), permObject.encode());
+
+    permissionSet = new JsonObject()
+        .put("moduleId","moduleB4-1.0.0")
+        .put("perms", new JsonArray()
+            .add(new JsonObject()
+                .put("permissionName", perm2)
+                .put("displayName", "Description 1")
+                .put("subPermissions", new JsonArray()
+                    .add(dummy))
+            )
+        );
+    response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    context.assertEquals(201, response.code);
+
+    permissionSet = new JsonObject()
+        .put("moduleId","moduleA5-1.0.0")
+        .put("perms", new JsonArray()
+            .add(new JsonObject()
+                .put("permissionName", dummy)
+                .put("displayName", "Description 1")
+            )
+        );
+    response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    context.assertEquals(201, response.code);
+
+    response = send(HttpMethod.GET, "/perms/permissions?includeDummy=true&query=permissionName%3D" + dummy, null, context);
+    context.assertEquals(200, response.code);
+    permObject = response.body.getJsonArray("permissions").getJsonObject(0);
+    context.assertEquals(dummy, permObject.getString("permissionName"));
+    context.assertEquals("moduleA5", permObject.getString("moduleName"));
+    context.assertEquals("1.0.0", permObject.getString("moduleVersion"));
+    context.assertFalse(permObject.getBoolean("dummy"), permObject.encode());
+  }
 
   @Test
   public void testPutPermsUsersByIdDummyPerm(TestContext context) {


### PR DESCRIPTION
Dummy permissions should not be assigned a context. They don't belong to the module where they happen to be referred to.

They should be assigned a context when they are really defined.

Furthermore the collision check in savePerms is wrong for. It checks if context is null and then assumes it's user-defined context.
If a permission has Mutable undefined or TRUE – then it'a user-defined permission.

This PR also makes it possible to use stock install.json for Okapi. OKAPI-985.