### PR TITLE
MODPERMS-126 user-defined perms are always mutable

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "permissions",
-      "version": "5.3",
+      "version": "6.0",
       "handlers" : [
         {
           "methods": [ "POST" ],

--- a/ramls/permissionUpload.json
+++ b/ramls/permissionUpload.json
@@ -34,10 +34,6 @@
         "type": "string"
       }
     },
-    "mutable": {
-      "description": "Whether or not this permission can change at runtime",
-      "type": "boolean"
-    },
     "visible": {
       "description": "Should this permission be hidden from users",
       "type": "boolean"

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -1896,7 +1896,6 @@ public class PermsAPI implements Perms {
       subPerms.add(s);
     }
     perm.setSubPermissions(subPerms);
-    perm.setMutable(entity.getMutable());
     perm.setVisible(entity.getVisible());
     perm.setTags(entity.getTags());
     perm.setMetadata(entity.getMetadata());

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -1897,6 +1897,7 @@ public class PermsAPI implements Perms {
     }
     perm.setSubPermissions(subPerms);
     perm.setVisible(entity.getVisible());
+    perm.setMutable(true); // user-defined perms are always mutable
     perm.setTags(entity.getTags());
     perm.setMetadata(entity.getMetadata());
     return perm;

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -918,7 +918,12 @@ public class RestVerticleTest {
     context.assertEquals(response.code, 201);
     context.assertEquals(uuid, response.body.getString("id")); // MODPERMS-84
 
-    response = send(HttpMethod.DELETE, "/perms/permissions/" + uuid,null, context);
+    response = send(HttpMethod.GET, "/perms/permissions/" + uuid, null, context);
+    context.assertEquals(response.code, 200);
+    context.assertTrue(Boolean.TRUE.equals(response.body.getBoolean("mutable")),
+        response.body.encodePrettily()); // MODPERMS-126
+
+    response = send(HttpMethod.DELETE, "/perms/permissions/" + uuid, null, context);
     context.assertEquals(response.code, 204);
   }
 


### PR DESCRIPTION
## Purpose
The original intent of the mutable field was to serve as an indicator that a permission was defined by the system.  However, for whatever reason, the property was not treated read-only.  This means while it was never the intention to allow users to create immutable permissions (those which cannot be modified/removed), it's technically possible.

This PR removes the mutable field from the permissionUpload.json schema.  

This is a breaking change.

*N.B.* Any user-defined, immutable permissions that already exist will be deprecated upon upgrade to Iris.

See https://issues.folio.org/browse/MODPERMS-126