### PR TITLE
MODPERMS-116 purge deprecated perms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
-
+bin
+.classpath
+.project
+.settings

--- a/ramls/permissions.raml
+++ b/ramls/permissions.raml
@@ -415,4 +415,17 @@ traits:
             body:
               text/plain:
                 example: "Internal server error"
-
+  /purge-deprecated:
+    post:
+      description: purge deprecated permissions
+      responses:
+        200:
+          description: "A list of permission names purged"
+          body:
+            application/json:
+              type: permissionNameListObject
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error"

--- a/ramls/permissions.raml
+++ b/ramls/permissions.raml
@@ -424,6 +424,11 @@ traits:
           body:
             application/json:
               type: permissionNameListObject
+        400:
+          description: "Bad request"
+          body:
+            text/plain:
+              example: "Bad request"
         500:
           description: "Internal server error"
           body:

--- a/src/main/java/org/folio/rest/impl/PermissionUtils.java
+++ b/src/main/java/org/folio/rest/impl/PermissionUtils.java
@@ -9,7 +9,6 @@ import org.folio.rest.jaxrs.model.OkapiPermission;
 import org.folio.rest.jaxrs.model.Permission;
 import org.folio.rest.jaxrs.model.PermissionNameListObject;
 import org.folio.rest.persist.PostgresClient;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.sqlclient.Row;

--- a/src/main/java/org/folio/rest/impl/PermissionUtils.java
+++ b/src/main/java/org/folio/rest/impl/PermissionUtils.java
@@ -1,10 +1,30 @@
 package org.folio.rest.impl;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import org.folio.rest.jaxrs.model.OkapiPermission;
 import org.folio.rest.jaxrs.model.Permission;
+import org.folio.rest.jaxrs.model.PermissionNameListObject;
+import org.folio.rest.persist.PostgresClient;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
 
 public class PermissionUtils {
+
+  private static final String SELECT_DEPRECATED_PERMS = "select id::text as id, jsonb->>'permissionName' as name "
+      + "from %s_mod_permissions.permissions where jsonb->>'deprecated' = 'true'";
+  private static final String PURGE_DEPRECATED_PERMS = "delete from %s_mod_permissions.permissions "
+      + "where jsonb->>'deprecated' = 'true'";
+  private static final String PURGE_DEPRECATED_SUB_PERMS = "update %s_mod_permissions.permissions "
+      + "set jsonb = jsonb_set(jsonb, '{subPermissions}', (jsonb->'subPermissions')::jsonb - array['%s', '%s']) "
+      + "where jsonb->'subPermissions' ?| array['%s', '%s']";
+  private static final String PURGE_DEPRECATED_PERMS_USERS = "update %s_mod_permissions.permissions_users "
+      + "set jsonb = jsonb_set(jsonb, '{permissions}', (jsonb->'permissions')::jsonb - array['%s', '%s']) "
+      + "where jsonb->'permissions' ?| array['%s', '%s']";
 
   private PermissionUtils() {
     
@@ -42,5 +62,49 @@ public class PermissionUtils {
         && Objects.equals(okapiPerm.getDescription(), perm.getDescription())
         && Objects.equals(okapiPerm.getDisplayName(), perm.getDisplayName())
         && Objects.equals(okapiPerm.getSubPermissions(), perm.getSubPermissions());
-  }  
+  }
+
+  /**
+   * Purge deprecated permissions for a given tenant.
+   * 
+   * @param pgClient {@link PostgresClient}
+   * @param tenantId tenant id
+   * @return {@link Future} with {@link PermissionNameListObject}
+   */
+  public static Future<PermissionNameListObject> purgeDeprecatedPermissions(PostgresClient pgClient, String tenantId) {
+    Promise<PermissionNameListObject> promise = Promise.promise();
+    pgClient.startTx(tx -> {
+      try {
+        pgClient.select(tx, String.format(SELECT_DEPRECATED_PERMS, tenantId), res -> {
+          PermissionNameListObject permNames = new PermissionNameListObject();
+          permNames.setTotalRecords(0);
+          @SuppressWarnings("rawtypes")
+          List<Future> futures = new ArrayList<Future>();
+          res.result()
+            .forEach(row -> {
+              String id = row.getString("id");
+              String name = row.getString("name");
+              futures.add(Future.<RowSet<Row>>future(p -> pgClient.execute(tx, String.format(PURGE_DEPRECATED_SUB_PERMS, tenantId, id, name, id, name), p)));
+              futures.add(Future.<RowSet<Row>>future(p -> pgClient.execute(tx, String.format(PURGE_DEPRECATED_PERMS_USERS, tenantId, id, name, id, name), p)));
+              futures.add(Future.<RowSet<Row>>future(p -> pgClient.execute(tx, String.format(PURGE_DEPRECATED_PERMS, tenantId), p)));
+              permNames.getPermissionNames().add(name);
+              permNames.setTotalRecords(permNames.getTotalRecords() + 1);
+            });
+          CompositeFuture.all(futures)
+            .onSuccess(ignore -> {
+              pgClient.endTx(tx, done -> done.mapEmpty());
+              promise.complete(permNames);
+            })
+            .onFailure(ex -> {
+              pgClient.rollbackTx(tx, done -> done.mapEmpty());
+              promise.fail(ex);
+            });
+        });
+      } catch (Exception e) {
+        pgClient.rollbackTx(tx, done -> done.mapEmpty());
+        promise.fail(e);
+      }
+    });
+    return promise.future();
+  }
 }

--- a/src/main/java/org/folio/rest/impl/PermissionUtils.java
+++ b/src/main/java/org/folio/rest/impl/PermissionUtils.java
@@ -3,6 +3,8 @@ package org.folio.rest.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.jaxrs.model.OkapiPermission;
 import org.folio.rest.jaxrs.model.Permission;
 import org.folio.rest.jaxrs.model.PermissionNameListObject;
@@ -82,8 +84,7 @@ public class PermissionUtils {
           }
           PermissionNameListObject permNames = new PermissionNameListObject();
           permNames.setTotalRecords(0);
-          @SuppressWarnings("rawtypes")
-          List<Future> futures = new ArrayList<Future>();
+          List<Future<RowSet<Row>>> futures = new ArrayList<Future<RowSet<Row>>>();
           res.result()
             .forEach(row -> {
               String id = row.getString("id");
@@ -94,7 +95,7 @@ public class PermissionUtils {
               permNames.getPermissionNames().add(name);
               permNames.setTotalRecords(permNames.getTotalRecords() + 1);
             });
-          CompositeFuture.all(futures)
+          GenericCompositeFuture.all(futures)
             .onSuccess(ignore -> {
               pgClient.endTx(tx, done -> promise.complete(permNames));
             })

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -1937,4 +1937,28 @@ public class PermsAPI implements Perms {
     }
     return criterion;
   }
+
+  @Override
+  public void postPermsPurgeDeprecated(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
+    try {
+      String tenantId = TenantTool.tenantId(okapiHeaders);
+      PostgresClient pgClient = PostgresClient.getInstance(vertxContext.owner(), tenantId);
+      PermissionUtils.purgeDeprecatedPermissions(pgClient, tenantId)
+        .onSuccess(res -> {
+          asyncResultHandler
+            .handle(Future.succeededFuture(PostPermsPurgeDeprecatedResponse.respond200WithApplicationJson(res)));
+        })
+        .onFailure(ex -> {
+          asyncResultHandler
+            .handle(Future.succeededFuture(PostPermsPurgeDeprecatedResponse.respond500WithTextPlain(ex.getCause()
+              .getMessage())));
+        });
+    } catch (Exception e) {
+      logger.error(e.getMessage(), e);
+      asyncResultHandler
+        .handle(Future.succeededFuture(PostPermsPurgeDeprecatedResponse.respond500WithTextPlain(e.getMessage())));
+    }
+  }
+
 }

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -1951,8 +1951,7 @@ public class PermsAPI implements Perms {
         })
         .onFailure(ex -> {
           asyncResultHandler
-            .handle(Future.succeededFuture(PostPermsPurgeDeprecatedResponse.respond500WithTextPlain(ex.getCause()
-              .getMessage())));
+            .handle(Future.succeededFuture(PostPermsPurgeDeprecatedResponse.respond500WithTextPlain(ex.getMessage())));
         });
     } catch (Exception e) {
       logger.error(e.getMessage(), e);

--- a/src/test/java/org/folio/rest/impl/PermsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/PermsAPITest.java
@@ -7,7 +7,9 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -216,4 +218,14 @@ public class PermsAPITest {
     }), null);
   }
 
+  @Test
+  public void testPostPermsPurgeDeprecatedBadTenant(TestContext context) {
+    PermsAPI api = new PermsAPI();
+    
+    Map<String, String> headers = new HashMap<>();
+    headers.put("x-okapi-tenant", "foo");
+    api.postPermsPurgeDeprecated(headers, context.asyncAssertSuccess(res -> {
+      context.assertEquals(500, res.getStatus());
+    }), vertx.getOrCreateContext());
+  }
 }

--- a/src/test/java/org/folio/rest/impl/PermsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/PermsAPITest.java
@@ -207,4 +207,13 @@ public class PermsAPITest {
     }), null);
   }
 
+  @Test
+  public void testPostPermsPurgeDeprecatedNullPointer(TestContext context) {
+    PermsAPI api = new PermsAPI();
+
+    api.postPermsPurgeDeprecated(null, context.asyncAssertSuccess(res -> {
+      context.assertEquals(500, res.getStatus());
+    }), null);
+  }
+
 }


### PR DESCRIPTION
Please see https://issues.folio.org/browse/MODPERMS-116 Create purge Deprecated API

Some minor changes from original JIRA description

- endpoint was changed from `/perms/permissions/purge-deprecated` to `/perms/purge-deprecated` because of conflict with `/perms/permissions/{id}`
- reused the existing [permissionNameListObject.json](https://github.com/folio-org/mod-permissions/blob/master/ramls/permissionNameListObject.json) rather than creating a new json to define the response. They have the exact same structure except property naming