### PR TITLE
MODPERMS-135 update subperms for perm replace

### DIFF
--- a/src/main/java/org/folio/rest/impl/PermissionUtils.java
+++ b/src/main/java/org/folio/rest/impl/PermissionUtils.java
@@ -21,11 +21,11 @@ public class PermissionUtils {
   private static final String PURGE_DEPRECATED_PERMS = "delete from %s_mod_permissions.permissions "
       + "where jsonb->>'deprecated' = 'true'";
   private static final String PURGE_DEPRECATED_SUB_PERMS = "update %s_mod_permissions.permissions "
-      + "set jsonb = jsonb_set(jsonb, '{subPermissions}', (jsonb->'subPermissions')::jsonb - array['%s', '%s']) "
-      + "where jsonb->'subPermissions' ?| array['%s', '%s']";
+      + "set jsonb = jsonb_set(jsonb, '{subPermissions}', (jsonb->'subPermissions')::jsonb - '%s') "
+      + "where jsonb->'subPermissions' ? '%s'";
   private static final String PURGE_DEPRECATED_PERMS_USERS = "update %s_mod_permissions.permissions_users "
-      + "set jsonb = jsonb_set(jsonb, '{permissions}', (jsonb->'permissions')::jsonb - array['%s', '%s']) "
-      + "where jsonb->'permissions' ?| array['%s', '%s']";
+      + "set jsonb = jsonb_set(jsonb, '{permissions}', (jsonb->'permissions')::jsonb - '%s') "
+      + "where jsonb->'permissions' ? '%s'";
 
   private PermissionUtils() {
     
@@ -86,10 +86,9 @@ public class PermissionUtils {
           List<Future<RowSet<Row>>> futures = new ArrayList<Future<RowSet<Row>>>();
           res.result()
             .forEach(row -> {
-              String id = row.getString("id");
               String name = row.getString("name");
-              futures.add(Future.<RowSet<Row>>future(p -> pgClient.execute(tx, String.format(PURGE_DEPRECATED_SUB_PERMS, tenantId, id, name, id, name), p)));
-              futures.add(Future.<RowSet<Row>>future(p -> pgClient.execute(tx, String.format(PURGE_DEPRECATED_PERMS_USERS, tenantId, id, name, id, name), p)));
+              futures.add(Future.<RowSet<Row>>future(p -> pgClient.execute(tx, String.format(PURGE_DEPRECATED_SUB_PERMS, tenantId, name, name), p)));
+              futures.add(Future.<RowSet<Row>>future(p -> pgClient.execute(tx, String.format(PURGE_DEPRECATED_PERMS_USERS, tenantId, name, name), p)));
               futures.add(Future.<RowSet<Row>>future(p -> pgClient.execute(tx, String.format(PURGE_DEPRECATED_PERMS, tenantId), p)));
               permNames.getPermissionNames().add(name);
               permNames.setTotalRecords(permNames.getTotalRecords() + 1);
@@ -108,4 +107,5 @@ public class PermissionUtils {
     });
     return promise.future();
   }
+
 }

--- a/src/main/java/org/folio/rest/impl/TenantPermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantPermsAPI.java
@@ -11,6 +11,8 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -46,6 +48,10 @@ public class TenantPermsAPI implements Tenantpermissions {
   private static final String TABLE_NAME_PERMS = "permissions";
   private static final String TABLE_NAME_PERMSUSERS = "permissions_users";
   public static final String DEPRECATED_PREFIX = "(deprecated) ";
+  
+  private static final String ADD_PERM_TO_SUB_PERMS = "update %s_mod_permissions.permissions "
+      + "set jsonb = jsonb_set(jsonb, '{subPermissions}', (jsonb->'subPermissions')::jsonb || '[\"%s\"]'::jsonb) "
+      + "where jsonb->'subPermissions' ? '%s' and not jsonb->'subPermissions' ? '%s' ";
 
   private final Logger logger = LogManager.getLogger(TenantPermsAPI.class);
 
@@ -392,8 +398,15 @@ perm.setModuleName(moduleId.getProduct());
     return savePermList(moduleId, new ArrayList<>(permList.keySet()), vertxContext, tenantId)
         .compose(v -> {
           List<Future> futures = new ArrayList<>(permList.size());
+          PostgresClient pgClient = PostgresClient.getInstance(vertxContext.owner(), tenantId);
           permList.keySet().forEach(okapiPerm -> {
+            String newPermName = okapiPerm.getPermissionName();
             permList.get(okapiPerm).forEach(replaced -> {
+              // add new permission name to all relevant sub permissions
+              String oldPermName = replaced.getPermissionName();
+              futures.add(Future.<RowSet<Row>>future(p -> pgClient.execute(connection,
+                  String.format(ADD_PERM_TO_SUB_PERMS, tenantId, newPermName, oldPermName, newPermName), p)));
+              
               replaced.getGrantedTo().forEach(permUser -> {
                 String permissionName = okapiPerm.getPermissionName();
                 futures.add(addPermissionToUser(connection, permUser.toString(), permissionName,

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -519,6 +519,9 @@ public class RestVerticleTest {
 
   @Test
   public void testPurgeDeprecatedPerm(TestContext context) {
+    // clean up deprecated perms first
+    Response response = send(HttpMethod.POST, "/perms/purge-deprecated", null, context);
+
     // seed permissions
     String perm1 = "permA" + UUID.randomUUID().toString();
     String perm2 = "permB" + UUID.randomUUID().toString();
@@ -532,7 +535,7 @@ public class RestVerticleTest {
             .add(new JsonObject()
                 .put("permissionName", perm2)
                 .put("displayName", "Description 2")));
-    Response response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
     context.assertEquals(201, response.code);
     
     // seed perm user
@@ -619,11 +622,13 @@ public class RestVerticleTest {
     permUsersObject = response.body;
     context.assertTrue(permUsersObject.getJsonArray("permissions").contains(perm1));
     context.assertFalse(permUsersObject.getJsonArray("permissions").contains(perm2)); // perm2 is gone
-    
   }
 
   @Test
   public void testPermissionNameReplace(TestContext context) {
+    // clean up deprecated perms first
+    Response response = send(HttpMethod.POST, "/perms/purge-deprecated", null, context);
+
     // seed modA with perm1 and perm2
     String perm1 = "permA" + UUID.randomUUID().toString();
     String perm2 = "permB" + UUID.randomUUID().toString();
@@ -632,7 +637,7 @@ public class RestVerticleTest {
         .put("perms", new JsonArray()
             .add(new JsonObject().put("permissionName", perm1))
             .add(new JsonObject().put("permissionName", perm2)));
-    Response response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
+    response = send(HttpMethod.POST, "/_/tenantpermissions", permissionSet.encode(), context);
     context.assertEquals(201, response.code);
 
     // seed modB with perm3 that has perm1 and perm2 in subperms


### PR DESCRIPTION
Please see https://issues.folio.org/browse/MODPERMS-135: "replaces" processing doesn't update permissions, only permission assignments

Note:

- Used direct sql in case that subperms do not have matching `childOf` defined
- Also updated earlier commit to use only perm name, not perm id (not needed) to purge deprecated ones