### PR TITLE
MODPERMS-136 Add notes about static permission migration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,7 @@ There are several changes related to migration of static (system-defined) permis
 * Orphaned system-defined permissions - those which are marked as immutable and are no longer present an any enabled module descriptor - will automatically be deprecated when upgrading mod-permissions.
 
 ### Deployment Considerations
-* OKAPI [v4.6.0](https://github.com/folio-org/okapi/releases/tag/v4.6.0) or greater ([v4.7.2](https://github.com/folio-org/okapi/releases/tag/v4.7.2) is highly recommended) is required to benefit from these changes.
+* OKAPI [v4.6.0](https://github.com/folio-org/okapi/releases/tag/v4.6.0) or greater ([v4.7.2](https://github.com/folio-org/okapi/releases/tag/v4.7.2) or greater is highly recommended) is required to benefit from these changes.
 * ***Contrary to earlier communications, it is NOT required to upgrade mod-permissions first or last.  It is also NOT required that you resolve duplicate permissions prior to upgrading to mod-permissions-5.13.0***
 
 ### Stories / Bugs:
@@ -166,4 +166,3 @@ There are several changes related to migration of static (system-defined) permis
 
 ## 2017-05-11
  * Update to RMB release 11.0.0
-

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@ There are several changes related to migration of static (system-defined) permis
 * All system-defined permissions will now include context about the module that defined them (new permission fields `moduleName`/`moduleVersion`).
 * Once v5.13.0 is enabled, duplicate permission definitions are not allowed.  If a permission (name) is defined by multiple module descriptors the upgrade will fail with an appropriate error message. 
 * The `mutable` property will now be ignored when creating or updating permissions.  This is a system-controlled field.
-* Orphaned system-defined permissions - those which are marked as immutable and are no longer present an any enabled module descriptor - will automatically be deprecated when upgrading mod-permissions.
+* Orphaned system-defined permissions - those which are marked as immutable and are no longer present in any enabled module descriptor - will automatically be deprecated when upgrading mod-permissions.
 
 ### Deployment Considerations
 * OKAPI [v4.6.0](https://github.com/folio-org/okapi/releases/tag/v4.6.0) or greater ([v4.7.2](https://github.com/folio-org/okapi/releases/tag/v4.7.2) or greater is highly recommended) is required to benefit from these changes.

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,7 @@ There are several changes related to migration of static (system-defined) permis
   * For now, the call to enable the module (install/upgrade) will fail with an appropriate error message.  
   * In the future we'd like to do something like rename the user-defined permissions and adjust assignments as needed. 
 * All system-defined permissions will now include context about the module that defined them (new permission fields `moduleName`/`moduleVersion`).
-* Duplicate permission definitions are not allowed.  If a permission (name) is defined by multiple module descriptors the upgrade will fail with an appropriate error message. 
+* Once v5.13.0 is enabled, duplicate permission definitions are not allowed.  If a permission (name) is defined by multiple module descriptors the upgrade will fail with an appropriate error message. 
 * The `mutable` property will now be ignored when creating or updating permissions.  This is a system-controlled field.
 * Orphaned system-defined permissions - those which are marked as immutable and are no longer present an any enabled module descriptor - will automatically be deprecated when upgrading mod-permissions.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 There are several changes related to migration of static (system-defined) permissions introduced in this release:
 
 * Permissions can now be renamed via a new `replaces` property.  Perm-users (Assignments) and PermissionSet sub-permissions will be updated automatically.
-  * Example:  `foo.get` replaces `foo.read`, `foo.view`.  Any users which were assigned either `foo.read` or `foo.view` would automatically be granted `foo.get` and would no longer be assigned the replaced permission.
+  * Example:  `foo.get` replaces `foo.read`, `foo.view`.  Any users which were assigned either `foo.read` or `foo.view` would automatically be granted `foo.get`.  Permissions `foo.read` and `foo.view` would be marked deprecated.
 * When permissions that once appeared in a module descriptor are removed in a newer version of the module descriptor, they will be marked deprecated. 
   * For now, this means the `displayName` of these permissions will be prefixed with `(deprecated) `, but the permissions will not be filtered out of any API calls. 
  * In the future we'd like to filter deprecated permissions out of API responses unless they're specifically requested.  This feature, however, did not make it into v5.13.0.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,11 +3,11 @@
 ### Static Permission Migration
 There are several changes related to migration of static (system-defined) permissions introduced in this release:
 
-* Permissions can now be renamed via a new `replaces` property.  Perm-users (Assignments) and PermissionSet sub-permissions will be updated automatically.
-  * Example:  `foo.get` replaces `foo.read`, `foo.view`.  Any users which were assigned either `foo.read` or `foo.view` would automatically be granted `foo.get`.  Permissions `foo.read` and `foo.view` would be marked deprecated.
 * When permissions that once appeared in a module descriptor are removed in a newer version of the module descriptor, they will be marked deprecated. 
   * For now, this means the `displayName` of these permissions will be prefixed with `(deprecated) `, but the permissions will not be filtered out of any API calls. 
- * In the future we'd like to filter deprecated permissions out of API responses unless they're specifically requested.  This feature, however, did not make it into v5.13.0.
+  * In the future we'd like to filter deprecated permissions out of API responses unless they're specifically requested.  This feature, however, did not make it into v5.13.0.
+* Permissions can now be renamed via a new `replaces` property.  Perm-users (Assignments) and PermissionSet sub-permissions will be updated automatically.
+  * Example:  `foo.get` replaces `foo.read`, `foo.view`.  Any users which were assigned either `foo.read` or `foo.view` would automatically be granted `foo.get`.  Permissions `foo.read` and `foo.view` would be marked deprecated.
 * A new [purgeDeprecated API](https://s3.amazonaws.com/foliodocs/api/mod-permissions/permissions.html#perms_purge_deprecated_post) has been introduced to allow an operator to purge deprecated permissions.  This will:
   * Remove deprecated permissions from the system
   * Remove deprecated permission names from user's permission assignments


### PR DESCRIPTION
## Purpose
Document changes in v5.13.0 related to static permission migration.

See https://issues.folio.org/browse/MODPERMS-136

## Approach
* Update the NEWS file

## Context / Notes
Also done, but outside the scope of this PR:
* Amend the [v5.13.0 release notes](https://github.com/folio-org/mod-permissions/releases/tag/v5.13.0) 
* Add similar notes to the [Iris release notes wiki page](https://wiki.folio.org/display/REL/R1+2021+%28Iris%29+Release+Notes#R12021(Iris)ReleaseNotes-Permissions)