### PR TITLE
MODPERMS-151: Release v5.14.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-## 2021-09-30 v5.14.1
+## 2021-10-01 v5.14.2
 
 [MODPERMS-154](https://issues.folio.org/browse/MODPERMS-154) Update RMB to 33.1.1 and Vert.x 4.1.4
+
+NOTE: There was no v5.14.1 due to errors preparing the release.
 
 ## 2021-05-27 v5.14.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-permissions</artifactId>
-  <version>5.14.2</version>
+  <version>5.15.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -382,7 +382,7 @@
     <url>https://github.com/folio-org/mod-permissions</url>
     <connection>scm:git:git://github.com:folio-org/mod-permissions.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-permissions.git</developerConnection>
-    <tag>v5.14.2</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-permissions</artifactId>
-  <version>5.15.0-SNAPSHOT</version>
+  <version>5.14.2</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -382,7 +382,7 @@
     <url>https://github.com/folio-org/mod-permissions</url>
     <connection>scm:git:git://github.com:folio-org/mod-permissions.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-permissions.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v5.14.2</tag>
   </scm>
 
 </project>


### PR DESCRIPTION
This is to correct mistakes I made preparing version 5.14.1. See NEWS.md for a note about what happened to 5.14.1. There now will be no release with that version number.

**What happened**
I squashed the commits for 5.14.1 when I merged it which had the unfortunate effect of removing the tag generated by maven. When I added the tag to master, Jenkins would not build it (error `Git release tag and maven version mismatch`). Theory: Jenkins expects release tags to not be on master, which is what will be the case when not squashing when merging the PR.

**What I did to fix things**
I removed the tag locally and remotely for v5.14.1. I think this is the right approach since there won't be a release for this tag and because we don't want people becoming confused when they see it in the git log or in the Github UI. I also made a note about 5.14.1 in the Jira releases as well in case anyone wonders what happened there.

There still is one commit from the merger of #133 which is the result of my bad squash merge. I think this is ok since github doesn't allow for PRs to be removed. Theoretically I could have tried to "revert" the PR, but based on what I've read about others experience with that feature, I didn't trust it. It wouldn't have simplified things much anyway since it it creates a new PR as well.