### PR TITLE
MODPERMS-156: Perms users request results in invalid SQL

### DIFF
--- a/ramls/permissionUser.json
+++ b/ramls/permissionUser.json
@@ -4,11 +4,11 @@
   "description": "A user that owns zero or more permissions",
   "properties": {
     "id": {
-      "description": "The globally unique (UUIDO) id of the user",
+      "description": "The primary key (UUID) of this permissionUser record",
       "type": "string"
     },
     "userId": {
-      "description": "A foreign key (UUID) from the users module",
+      "description": "A foreign key to the id field (UUID) of the user record in the users module",
       "type": "string"
     },
     "permissions": {
@@ -21,5 +21,8 @@
       "$ref" : "raml-util/schemas/metadata.schema"
     }
   },
+  "required": [
+    "userId"
+  ],
   "additionalProperties": false
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -26,13 +26,7 @@
       "tableName" : "permissions_users",
       "fromModuleVersion" : "5.0",
       "withMetadata" : true,
-      "index" : [
-        {
-          "fieldName" : "id",
-          "tOps" : "ADD",
-          "caseSensitive": true,
-          "removeAccents": false
-        },
+      "uniqueIndex" : [
         {
           "fieldName" : "userId",
           "tOps" : "ADD",


### PR DESCRIPTION
POST /perms/users fails with an SQL error if no userId is
supplied.

To fix this userId is marked as required in permissionUser.json and
is converted into a uniqueIndex in schema.json.

This replaces the Java code that check for duplicate userId, that code
is removed.

The id is always the primary key, this has always a unique index.
The Java code that checks for duplicate id is not needed.
The non-unique index for id is not needed and is removed
from schema.json.

The id variable name incorrectly was userid and is renamed to id.