### PR TITLE
Check for token to check for auth enabled MODPERMS-174

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ This was introduced in mod-permissions version 6.0.0.
 
 The restrictions work as follows:
 
-1. If module permissions or operating user permissions contains the permission
-to be granted for a user, the operation is allowed.
-
-2. If there's no user of the API (no authentication token), the operation
+1. If auth is disabled for the tenant where permissions are added, the operation
 is allowed.
+
+2. If module permissions or operating user permissions contains the permission
+to be granted for a user, the operation is allowed.
 
 3. If new permission name is `perms.users.assign.okapi` or starts with
 `okapi.` and operating user permissions and module permissions doesn't

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -1041,10 +1041,7 @@ public class PermsAPI implements Perms {
     if (token == null) { // auth not enabled
       return Future.succeededFuture();
     }
-    String operatingUser = okapiHeaders.get(XOkapiHeaders.USER_ID);
-    if (operatingUser == null) {
-      return Future.succeededFuture();
-    }
+    String operatingUser = okapiHeaders.getOrDefault(XOkapiHeaders.USER_ID, "null");
     return getOperatingPermissions(vertxContext, tenantId, operatingUser)
         .compose(operatingPermissions -> {
           JsonObject tokenObject = getPayloadWithoutValidation(token);

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -1037,13 +1037,17 @@ public class PermsAPI implements Perms {
     if (okapiHeaders == null) { // when POSTing permission sets
       return Future.succeededFuture();
     }
+    String token = okapiHeaders.get(XOkapiHeaders.TOKEN);
+    if (token == null) { // auth not enabled
+      return Future.succeededFuture();
+    }
     String operatingUser = okapiHeaders.get(XOkapiHeaders.USER_ID);
     if (operatingUser == null) {
       return Future.succeededFuture();
     }
     return getOperatingPermissions(vertxContext, tenantId, operatingUser)
         .compose(operatingPermissions -> {
-          JsonObject tokenObject = getPayloadWithoutValidation(okapiHeaders.get(XOkapiHeaders.TOKEN));
+          JsonObject tokenObject = getPayloadWithoutValidation(token);
           Future<List<String>> futurePerms;
           if (tokenObject != null) {
             JsonArray extra_permissions = tokenObject.getJsonArray("extra_permissions");

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -1583,6 +1583,7 @@ public class RestVerticleTest {
         .set("Content-type", contentType);
     if (okapiUserId != null) {
       headers.add(XOkapiHeaders.USER_ID, okapiUserId);
+      headers.add(XOkapiHeaders.TOKEN, makeFakeJWT("user", okapiUserId, tenant, null));
     }
     return send(headers, method, path, content, context);
   }


### PR DESCRIPTION
Previously, if X-Okapi-User-Id was present mod-permissions would
use that as an indication that auth was enabled for the tenant. This
is indeed the case if operating user is the same as tenant user.
Fix by check for X-Okapi-Token being present.