### PR TITLE
FOLIO-3231: Replace runLintRamlCop/publishAPI by doApiLint/doApiDoc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,18 +1,21 @@
 
 
 buildMvn {
-  publishModDescriptor = 'yes'
-  publishAPI = 'yes'
-  mvnDeploy = 'yes'
-  runLintRamlCop = 'yes'
+  publishModDescriptor = true
+  mvnDeploy = true
   doKubeDeploy = true
   buildNode = 'jenkins-agent-java11'
 
+  doApiLint = true
+  doApiDoc = true
+  apiTypes = 'RAML'
+  apiDirectories = 'ramls'
+
   doDocker = {
     buildJavaDocker {
-      publishMaster = 'yes'
-      healthChk = 'yes'
-      healthChkCmd = 'curl -sS --fail -o /dev/null  http://localhost:8081/apidocs/ || exit 1'
+      publishMaster = true
+      healthChk = true
+      healthChkCmd = 'wget --no-verbose --tries=1 --spider http://localhost:8081/admin/health || exit 1'
     }
   }
 }

--- a/ramls/permission.json
+++ b/ramls/permission.json
@@ -54,7 +54,7 @@
     "deprecated": {
       "description": "Indicates whether this permissions has been marked for deletion (soft deleted)",
       "type": "boolean",
-      "default": "false"
+      "default": false
     },
     "moduleName": {
       "description": "The name of the module (not including version) that defined this permission",


### PR DESCRIPTION
runLintRamlCop and publishAPI are deprecated.
doApiLint and doApiDoc are the new way.
For details see https://issues.folio.org/browse/FOLIO-3231

The change in ramls/permission.json fixes the bug reported by doApiLint.

For the new healthChkCmd see https://issues.folio.org/browse/FOLIO-3407