### PR TITLE
Delete bad users, add constraint MODPERMS-177

### DIFF
--- a/src/main/java/org/folio/rest/impl/PermissionUtils.java
+++ b/src/main/java/org/folio/rest/impl/PermissionUtils.java
@@ -17,15 +17,18 @@ import io.vertx.sqlclient.Tuple;
 public class PermissionUtils {
 
   private static final String SELECT_DEPRECATED_PERMS = "select id::text as id, jsonb->>'permissionName' as name "
-      + "from %s_mod_permissions.permissions where jsonb->>'deprecated' = 'true'";
-  private static final String PURGE_DEPRECATED_PERMS = "delete from %s_mod_permissions.permissions "
-      + "where jsonb->>'deprecated' = 'true'";
-  private static final String PURGE_DEPRECATED_SUB_PERMS = "update %s_mod_permissions.permissions "
-      + "set jsonb = jsonb_set(jsonb, '{subPermissions}', (jsonb->'subPermissions')::jsonb - $1) "
-      + "where jsonb->'subPermissions' ? $2";
-  private static final String PURGE_DEPRECATED_PERMS_USERS = "update %s_mod_permissions.permissions_users "
-      + "set jsonb = jsonb_set(jsonb, '{permissions}', (jsonb->'permissions')::jsonb - $1) "
-      + "where jsonb->'permissions' ? $2";
+      + "from %s_mod_permissions." + PermsAPI.TABLE_NAME_PERMS + " where jsonb->>'deprecated' = 'true'";
+  private static final String PURGE_DEPRECATED_PERMS = "delete from %s_mod_permissions."
+      + PermsAPI.TABLE_NAME_PERMS
+      + " where jsonb->>'deprecated' = 'true'";
+  private static final String PURGE_DEPRECATED_SUB_PERMS = "update %s_mod_permissions."
+      + PermsAPI.TABLE_NAME_PERMS
+      + " set jsonb = jsonb_set(jsonb, '{subPermissions}', (jsonb->'subPermissions')::jsonb - $1)"
+      + " where jsonb->'subPermissions' ? $2";
+  private static final String PURGE_DEPRECATED_PERMS_USERS = "update %s_mod_permissions."
+      + PermsAPI.TABLE_NAME_PERMSUSERS
+      + " set jsonb = jsonb_set(jsonb, '{permissions}', (jsonb->'permissions')::jsonb - $1)"
+      + " where jsonb->'permissions' ? $2";
 
   public static final String PERMS_USERS_ASSIGN_IMMUTABLE = "perms.users.assign.immutable";
   public static final String PERMS_USERS_ASSIGN_MUTABLE = "perms.users.assign.mutable";

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -124,9 +124,8 @@ public class PermsAPI implements Perms {
     }
   }
 
-  private static final String TABLE_NAME_PERMS = "permissions";
-  private static final String TABLE_NAME_PERMSUSERS = "permissions_users";
-  private static final String USER_NAME_FIELD = "'username'";
+  public static final String TABLE_NAME_PERMSUSERS = "permissions_users";
+  public static final String TABLE_NAME_PERMS = "permissions";
   private static final String USER_ID_FIELD = "'userId'";
   private static final String ID_FIELD = "id";
   private static final String UNABLE_TO_UPDATE_DERIVED_FIELDS = "Unable to update derived fields: ";

--- a/src/main/resources/templates/db_scripts/perms_users_sanitize.sql
+++ b/src/main/resources/templates/db_scripts/perms_users_sanitize.sql
@@ -1,0 +1,10 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'permissions_users_userid_not_null') THEN
+    DELETE FROM ${myuniversity}_${mymodule}.permissions_users WHERE jsonb->>'userId' IS NULL;
+    ALTER TABLE ${myuniversity}_${mymodule}.permissions_users
+      ADD CONSTRAINT permissions_users_userid_not_null CHECK (jsonb->>'userId' IS NOT NULL);
+  END IF;
+END;
+$$;
+

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1,5 +1,10 @@
 {
-  "scripts" : [],
+  "scripts" : [
+    {
+      "run": "after",
+      "snippetPath": "perms_users_sanitize.sql"
+    }
+  ],
   "tables" : [
     {
       "tableName" : "permissions",

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -30,11 +30,13 @@ import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.impl.PermissionUtils;
+import org.folio.rest.impl.PermsAPI;
 import org.folio.rest.impl.PermsCache;
 import org.folio.rest.impl.TenantPermsAPI;
 import org.folio.rest.jaxrs.model.OkapiPermission;
 import org.folio.rest.jaxrs.model.OkapiPermissionSet;
 import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.rest.jaxrs.model.PermissionUser;
 import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.NetworkUtils;
@@ -3118,5 +3120,12 @@ public class RestVerticleTest {
     response = send(HttpMethod.GET, "/perms/users?offset=2&limit=3", null, context);
     context.assertEquals(200, response.code);
     context.assertEquals(3, response.body.getJsonArray("permissionUsers").size());
+  }
+
+  @Test
+  public void testUserIdNull(TestContext context) {
+    PermissionUser u = new PermissionUser().withId(UUID.randomUUID().toString());
+    PostgresClient.getInstance(vertx, "diku").save(PermsAPI.TABLE_NAME_PERMSUSERS, u)
+        .onComplete(context.asyncAssertFailure(e -> context.assertTrue(e.getMessage().contains("permissions_users_userid_not_null"))));
   }
 }

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -3126,6 +3126,6 @@ public class RestVerticleTest {
   public void testUserIdNull(TestContext context) {
     PermissionUser u = new PermissionUser().withId(UUID.randomUUID().toString());
     PostgresClient.getInstance(vertx, "diku").save(PermsAPI.TABLE_NAME_PERMSUSERS, u)
-        .onComplete(context.asyncAssertFailure(e -> context.assertTrue(e.getMessage().contains("permissions_users_userid_not_null"))));
+        .onComplete(context.asyncAssertFailure(e -> assertThat(e.getMessage(), containsString("permissions_users_userid_not_null"))));
   }
 }


### PR DESCRIPTION
Try to keep the table name definitions in one place at least in Java.

The code that saves bad users is not yet discovered. This is just a repair, that will make it harder, but not impossible
to create bad users again (for example a JSONB with userId and additional property such as tags).
