### PR TITLE
Migrate only users having perms.all MODPERMS-184

### DIFF
--- a/src/main/java/org/folio/rest/impl/PermissionUtils.java
+++ b/src/main/java/org/folio/rest/impl/PermissionUtils.java
@@ -34,7 +34,7 @@ public class PermissionUtils {
   public static final String PERMS_USERS_ASSIGN_MUTABLE = "perms.users.assign.mutable";
   public static final String PERMS_USERS_ASSIGN_OKAPI = "perms.users.assign.okapi";
   public static final String PERMS_OKAPI_ALL = "okapi.all";
-  protected static final String [] PERMS_MIGRATE = { "perms.users.item.post", "perms.users.item.put" };
+  protected static final String [] PERMS_MIGRATE = { "perms.all" };
 
   private PermissionUtils() {
 

--- a/src/test/java/org/folio/permstest/RestVerticleTest.java
+++ b/src/test/java/org/folio/permstest/RestVerticleTest.java
@@ -3025,22 +3025,6 @@ public class RestVerticleTest {
     response = send(HttpMethod.POST, "/perms/users", permsUser.encode(), context);
     context.assertEquals(201, response.code);
 
-    String operatorUserId2 = UUID.randomUUID().toString();
-    permsUser = new JsonObject()
-        .put("id", UUID.randomUUID().toString())
-        .put("userId", operatorUserId2)
-        .put("permissions", new JsonArray().add("perms.users.item.post"));
-    response = send(HttpMethod.POST, "/perms/users", permsUser.encode(), context);
-    context.assertEquals(201, response.code);
-
-    String operatorUserId3 = UUID.randomUUID().toString();
-    permsUser = new JsonObject()
-        .put("id", UUID.randomUUID().toString())
-        .put("userId", operatorUserId3)
-        .put("permissions", new JsonArray().add("perms.users.item.put"));
-    response = send(HttpMethod.POST, "/perms/users", permsUser.encode(), context);
-    context.assertEquals(201, response.code);
-
     // announce Okapi
     JsonObject okapiSet = new JsonObject()
         .put("moduleId", "okapi-1.0.0")
@@ -3106,16 +3090,6 @@ public class RestVerticleTest {
     response = send(HttpMethod.GET, "/perms/users/" + operatorUserId + "?indexField=userId", null, context);
     context.assertEquals(200, response.code);
     context.assertEquals(new JsonArray(List.of("perms.all", PermissionUtils.PERMS_USERS_ASSIGN_IMMUTABLE, PermissionUtils.PERMS_USERS_ASSIGN_MUTABLE)),
-        response.body.getJsonArray("permissions"));
-
-    response = send(HttpMethod.GET, "/perms/users/" + operatorUserId2 + "?indexField=userId", null, context);
-    context.assertEquals(200, response.code);
-    context.assertEquals(new JsonArray(List.of("perms.users.item.post", PermissionUtils.PERMS_USERS_ASSIGN_IMMUTABLE, PermissionUtils.PERMS_USERS_ASSIGN_MUTABLE)),
-        response.body.getJsonArray("permissions"));
-
-    response = send(HttpMethod.GET, "/perms/users/" + operatorUserId3 + "?indexField=userId", null, context);
-    context.assertEquals(200, response.code);
-    context.assertEquals(new JsonArray(List.of("perms.users.item.put", PermissionUtils.PERMS_USERS_ASSIGN_IMMUTABLE, PermissionUtils.PERMS_USERS_ASSIGN_MUTABLE)),
         response.body.getJsonArray("permissions"));
 
     response = send(HttpMethod.GET, "/perms/users/" + okapiOperatorId + "?indexField=userId", null, context);


### PR DESCRIPTION
Partly reverts MODPERMS-182 where users with perms.users.item.post,
perms.users.item.put was migrated.