### PR TITLE
MODPERMS-214: permissions interface 5.5 -> 5.6 for module replaces

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "permissions",
-      "version": "5.5",
+      "version": "5.6",
       "handlers": [
         {
           "methods": [


### PR DESCRIPTION
https://issues.folio.org/browse/MODPERMS-214

Upgrading to Nolana to Orchid-GA fails when the upgrade from mod-data-import-converter-storage to mod-di-converter-storage (rename!) is executed before the upgrade from mod-permissions.

Reason: The module rename requires the Orchid version of mod-permissions.

Fix: Add a dependency to ModuleDescriptors to enforce the upgrade order:

* Bump mod-permissions' permissions interface from 5.5 to 5.6.
* Add a permissions 5.6 dependency to mod-di-converter-storage.