### PR TITLE
MODPERMS-220: Delete unused hasPermissions from GET /perms/users API

### DIFF
--- a/ramls/permissions.raml
+++ b/ramls/permissions.raml
@@ -49,12 +49,6 @@ traits:
         description: "A query string to filter users based on matching criteria in fields."
         required: false
         type: string
-  byPermission:
-    queryParameters:
-      hasPermissions:
-        description: "A list of permissions that any returned users must possess."
-        required: false
-        type: string
   byMember:
     queryParameters:
       memberOf:
@@ -83,8 +77,7 @@ traits:
         pageable,
         pageable_legacy,
         sortable,
-        queryable,
-        byPermission
+        queryable
       ]
       responses:
         200:

--- a/src/main/java/org/folio/rest/impl/PermsAPI.java
+++ b/src/main/java/org/folio/rest/impl/PermsAPI.java
@@ -156,7 +156,7 @@ public class PermsAPI implements Perms {
   @Override
   public void getPermsUsers(String totalRecords,
       int offset, int limit, int length, int start, String sortBy, String query,
-      String hasPermissions, RoutingContext routingContext, Map<String, String> okapiHeaders,
+      RoutingContext routingContext, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     if (length != 10) {


### PR DESCRIPTION
The hasPermissions param of the GET /perms/users API has never been implemented.

Removing it is not a breaking change because it can still be passed and still doesn't do anything.