### PR TITLE
MODPERMS-222: Check "error" in GET /_/tenant/<tenantid> in PermsIT

### DIFF
--- a/src/test/java/org/folio/permstest/PermsIT.java
+++ b/src/test/java/org/folio/permstest/PermsIT.java
@@ -97,8 +97,9 @@ public class PermsIT {
     when().
       get(location + "?wait=30000").
     then().
-      statusCode(200).
-      body("complete", is(true));
+      statusCode(200).  // getting job record succeeds
+      body("complete", is(true)).  // job is complete
+      body("error", is(nullValue()));  // job has succeeded without error
   }
 
   @Test


### PR DESCRIPTION
https://s3.amazonaws.com/foliodocs/api/raml/r/tenant.html#tenant__operation_id__get

Error is indicated in the "error" property only, not in the HTTP status code!