### PR TITLE
MODPERMS-227: Remove duplicate permissions of a user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/src/test/java/org/folio/rest/impl/PermsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/PermsAPITest.java
@@ -3,9 +3,11 @@ package org.folio.rest.impl;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.unit.TestContext;
@@ -14,11 +16,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import javax.ws.rs.core.Response;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.XOkapiHeaders;
-import org.folio.postgres.testing.PostgresTesterContainer;
+import org.folio.permstest.TestUtil;
+import org.folio.rest.jaxrs.model.PermissionNameListObject;
+import org.folio.rest.jaxrs.model.PermissionNameObject;
+import org.folio.rest.jaxrs.model.PermissionUpload;
 import org.folio.rest.jaxrs.model.PermissionUser;
 import org.folio.rest.persist.PostgresClient;
 import org.junit.AfterClass;
@@ -30,13 +34,12 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class PermsAPITest {
 
-  private final Logger logger = LogManager.getLogger(PermsAPITest.class);
-  static Vertx vertx;
+  private static Vertx vertx;
 
   @BeforeClass
   public static void setup(TestContext context) {
     vertx = Vertx.vertx();
-        PostgresClient.setPostgresTester(new PostgresTesterContainer());
+    TestUtil.setupDiku(vertx).onComplete(context.asyncAssertSuccess());
   }
 
   @AfterClass
@@ -244,5 +247,111 @@ public class PermsAPITest {
     Assert.assertThrows(IllegalArgumentException.class, () -> PermsAPI.getPayloadWithoutValidation("a.b.c"));
     Assert.assertThrows(IllegalArgumentException.class, () -> PermsAPI.getPayloadWithoutValidation("a.YQo=.c"));
     Assert.assertEquals("{}", PermsAPI.getPayloadWithoutValidation("a.e30K.c").encode());
+  }
+
+  @Test
+  public void testUserPermissions(TestContext context) {
+    var perm1 = new PermissionUpload().withId(randomUuid()).withPermissionName("canBrewCoffee");
+    var perm2 = new PermissionUpload().withId(randomUuid()).withPermissionName("canDrinkCoffee");
+    var user = new PermissionUser().withId(randomUuid()).withUserId(randomUuid());
+    postPermission(perm1)
+    .compose(x -> postPermission(perm2))
+    .compose(x -> postUsers(user))
+    .compose(x -> postUsersPermissions(user, perm1))
+    .compose(x -> postUsersPermissions(user, perm2))
+    .compose(x -> postUsersPermissions(user, perm1))
+    .compose(x -> getUsersPermissions(user))
+    .compose(x -> assertPermissions(context, user, List.of("canBrewCoffee", "canDrinkCoffee")))
+    .compose(x -> deleteUsersPermissions(user, perm1))
+    .compose(x -> assertPermissions(context, user, List.of("canDrinkCoffee")))
+    .onComplete(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testDuplicatePermission(TestContext context) {
+    var perm1 = new PermissionUpload().withId(randomUuid()).withPermissionName("canSing");
+    var perm2 = new PermissionUpload().withId(randomUuid()).withPermissionName("canDance");
+    var user = new PermissionUser().withId(randomUuid()).withUserId(randomUuid())
+        .withPermissions(List.of("canSing", "canDance", "canSing"));
+    postPermission(perm1)
+    .compose(x -> postPermission(perm2))
+    .compose(x -> postUsers(user))
+    .compose(x -> getUsersPermissions(user))
+    .compose(x -> assertPermissions(context, user, List.of("canSing", "canDance")))
+    .compose(x -> putUsers(user))
+    .compose(x -> assertPermissions(context, user, List.of("canSing", "canDance")))
+    .compose(x -> PostgresClient.getInstance(vertx, "diku")
+        .execute("""
+                 UPDATE diku_mod_permissions.permissions_users
+                 SET jsonb = jsonb_set(jsonb, '{permissions}',
+                                       '["canDance", "canSing", "canDance", "canSing"]')
+                 WHERE id='""" + user.getId() + "'"))
+    .compose(x -> assertPermissions(context, user, List.of("canDance", "canSing", "canDance", "canSing")))
+    .compose(x -> getUsersPermissions(user))
+    .onComplete(context.asyncAssertSuccess(permissions -> {
+      assertThat(permissions, is(List.of("canDance", "canSing")));
+    }))
+    .compose(x -> deleteUsersPermissions(user, perm2))
+    .compose(x -> assertPermissions(context, user, List.of("canSing")))
+    .onComplete(context.asyncAssertSuccess());
+  }
+
+  private Future<Void> assertPermissions(TestContext context, PermissionUser user, List<String> expected) {
+    return PostgresClient.getInstance(vertx, "diku")
+      .selectSingle("""
+                    SELECT jsonb->'permissions'
+                    FROM diku_mod_permissions.permissions_users
+                    WHERE id='""" + user.getId() + "'")
+      .onComplete(context.asyncAssertSuccess(row -> {
+        assertThat(row.getJsonArray(0).getList(), is(expected));
+      }))
+      .mapEmpty();
+  }
+
+  private Future<Response> postUsers(PermissionUser user) {
+    var vertxContext = vertx.getOrCreateContext();
+    return Future.future(handler -> new PermsAPI()
+        .postPermsUsersTrans(user, vertxContext, headers(), handler));
+  }
+
+  private Future<Response> putUsers(PermissionUser user) {
+    var vertxContext = vertx.getOrCreateContext();
+    return Future.future(handler -> new PermsAPI()
+        .putPermsUsersById(user.getId(), user, headers(), handler, vertxContext));
+  }
+
+  private Future<Response> postPermission(PermissionUpload perm) {
+    var vertxContext = vertx.getOrCreateContext();
+    return Future.future(handler -> new PermsAPI().postPermsPermissions(perm, headers(), handler, vertxContext));
+  }
+
+  private Future<Response> postUsersPermissions(PermissionUser user, PermissionUpload perm) {
+    var vertxContext = vertx.getOrCreateContext();
+    var permissionNameObject = new PermissionNameObject().withPermissionName(perm.getPermissionName());
+    return Future.<Response>future(handler -> new PermsAPI().postPermsUsersPermissionsById(
+        user.getId(), null, permissionNameObject, headers(), handler, vertxContext));
+  }
+
+  private Future<List<Object>> getUsersPermissions(PermissionUser user) {
+    var vertxContext = vertx.getOrCreateContext();
+    return Future.<Response>future(handler -> new PermsAPI().getPermsUsersPermissionsById(
+        user.getId(), null, null, null, headers(), handler, vertxContext))
+        .map(response -> ((PermissionNameListObject) response.getEntity()).getPermissionNames());
+  }
+
+  private Future<Response> deleteUsersPermissions(PermissionUser user, PermissionUpload perm) {
+    var vertxContext = vertx.getOrCreateContext();
+    return Future.<Response>future(handler -> new PermsAPI().deletePermsUsersPermissionsByIdAndPermissionname(
+        user.getId(), perm.getPermissionName(), null, headers(), handler, vertxContext));
+  }
+
+  private String randomUuid() {
+    return UUID.randomUUID().toString();
+  }
+
+  private Map<String,String> headers() {
+    Map<String,String> headers = new CaseInsensitiveMap<>();
+    headers.put(XOkapiHeaders.TENANT, "diku");
+    return headers;
   }
 }

--- a/src/test/java/org/folio/rest/tools/utils/ModuleName.java
+++ b/src/test/java/org/folio/rest/tools/utils/ModuleName.java
@@ -1,0 +1,20 @@
+package org.folio.rest.tools.utils;
+
+public class ModuleName {
+  private static final String MODULE_NAME = "mod_permissions";
+  private static final String MODULE_VERSION = "99999.0.0";
+
+  /**
+   * The module name with minus replaced by underscore, for example {@code mod_foo_bar}.
+   */
+  public static String getModuleName() {
+    return MODULE_NAME;
+  }
+
+  /**
+   * The module version taken from pom.xml at compile time.
+   */
+  public static String getModuleVersion() {
+    return MODULE_VERSION;
+  }
+}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODPERMS-227

POST /perms/users and PUT /perms/users/{id} allow duplicate permissions.

These APIs should remove duplicates while retaining the order.

DELETE /perms/users/{id}/permissions/{permissionname} should remove all duplicates when writing the new permission list.

GET /perms/users/{id}/permissions should remove duplicate permissions while retaining the order.

By not rejecting POST and PUT with duplicate permissions this is not a breaking change but a bug fix.